### PR TITLE
Fix state management and UI regressions

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'models.dart';
-import 'game_screen.dart';
+import 'game_page.dart';
 import 'stats_page.dart';
 import 'settings_page.dart';
 
@@ -11,8 +11,6 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final app = context.watch<AppState>();
-
     return Scaffold(
       appBar: AppBar(
         title: const Text("Sudoku"),
@@ -66,7 +64,7 @@ class HomeScreen extends StatelessWidget {
           app.startGame(diff);
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const GameScreen()),
+            MaterialPageRoute(builder: (_) => const GamePage()),
           );
         },
         child: Text(title, style: const TextStyle(fontSize: 18)),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'models.dart';
 import 'home_screen.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(
     ChangeNotifierProvider(
       create: (_) => AppState()..load(),

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -23,19 +23,31 @@ class SettingsPage extends StatelessWidget {
             title: const Text("Системная"),
             value: AppTheme.system,
             groupValue: app.theme,
-            onChanged: (v) => v != null ? app.setTheme(v) : null,
+            onChanged: (v) {
+              if (v != null) {
+                app.setTheme(v);
+              }
+            },
           ),
           RadioListTile<AppTheme>(
             title: const Text("Светлая"),
             value: AppTheme.light,
             groupValue: app.theme,
-            onChanged: (v) => v != null ? app.setTheme(v) : null,
+            onChanged: (v) {
+              if (v != null) {
+                app.setTheme(v);
+              }
+            },
           ),
           RadioListTile<AppTheme>(
             title: const Text("Тёмная"),
             value: AppTheme.dark,
             groupValue: app.theme,
-            onChanged: (v) => v != null ? app.setTheme(v) : null,
+            onChanged: (v) {
+              if (v != null) {
+                app.setTheme(v);
+              }
+            },
           ),
           const Divider(height: 32),
 
@@ -45,7 +57,11 @@ class SettingsPage extends StatelessWidget {
               title: Text(lang.nameLocal),
               value: lang,
               groupValue: app.lang,
-              onChanged: (v) => v != null ? app.setLang(v) : null,
+              onChanged: (v) {
+                if (v != null) {
+                  app.setLang(v);
+                }
+              },
             ),
           ),
           const Divider(height: 32),

--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -25,7 +25,7 @@ class Board extends StatelessWidget {
         itemCount: 81,
         itemBuilder: (context, i) {
           final value = game.board[i];
-          final given = game.givens[i] != 0;
+          final given = game.given[i];
           final isSelected = app.selectedCell == i;
 
           // Проверка на ошибку (если пользователь ввёл неверное значение)

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -57,22 +57,26 @@ class ControlPanel extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
             _buildActionButton(
+              context,
               icon: Icons.undo,
               label: "Отмена",
               onTap: () => app.undoMove(),
             ),
             _buildActionButton(
+              context,
               icon: Icons.clear,
               label: "Стереть",
               onTap: () => app.eraseCell(),
             ),
             _buildActionButton(
+              context,
               icon: Icons.edit,
               label: app.notesMode ? "Заметки" : "Нотатки",
               active: app.notesMode,
               onTap: () => app.toggleNotesMode(),
             ),
             _buildActionButton(
+              context,
               icon: Icons.lightbulb,
               label: "Подсказка (${app.hintsLeft})",
               disabled: app.hintsLeft <= 0,
@@ -84,30 +88,35 @@ class ControlPanel extends StatelessWidget {
     );
   }
 
-  Widget _buildActionButton({
+  Widget _buildActionButton(
+    BuildContext context, {
     required IconData icon,
     required String label,
     required VoidCallback onTap,
     bool active = false,
     bool disabled = false,
   }) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final iconColor = disabled
+        ? theme.disabledColor
+        : (active ? colorScheme.primary : colorScheme.onSurface);
+
     return Column(
       children: [
         IconButton(
           onPressed: disabled ? null : onTap,
           icon: Icon(
             icon,
-            color: disabled
-                ? Colors.grey
-                : (active ? Colors.blueAccent : Colors.white),
+            color: iconColor,
           ),
         ),
         Text(
           label,
           style: TextStyle(
             color: disabled
-                ? Colors.grey
-                : (active ? Colors.blueAccent : Colors.white),
+                ? theme.disabledColor
+                : (active ? colorScheme.primary : colorScheme.onSurface),
             fontSize: 12,
           ),
         ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,22 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 import 'package:sudoku2/main.dart';
+import 'package:sudoku2/models.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Главный экран отображает список уровней', (tester) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AppState(),
+        child: const SudokuApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Выберите уровень сложности:'), findsOneWidget);
+    expect(find.text('Новичок'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- ensure Flutter bindings are initialized and persist theme, language, and audio preferences while tracking undoable moves and hints
- fix home screen navigation to the Sudoku board and correct board access to the given-cell state
- refresh control panel colors to respect the active theme and update the widget test for the current app shell

## Testing
- flutter test *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cfe23f348326b48e9c89ebb1650a