### PR TITLE
Add vibration toggle and feedback controls

### DIFF
--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -74,6 +74,12 @@ class SettingsPage extends StatelessWidget {
             secondary: const Icon(Icons.volume_up),
           ),
           SwitchListTile(
+            title: const Text("Вибрация"),
+            value: app.vibrationEnabled,
+            onChanged: (v) => app.toggleVibration(v),
+            secondary: const Icon(Icons.vibration),
+          ),
+          SwitchListTile(
             title: const Text("Фоновая музыка"),
             value: app.musicEnabled,
             onChanged: (v) => app.toggleMusic(v),


### PR DESCRIPTION
## Summary
- add a persistent vibration preference and expose it beside the sound settings
- trigger system sound and haptic feedback for correct moves, victories, and defeats
- ensure audio/vibration respect the updated switches so effects mute when disabled

## Testing
- `flutter analyze` *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca90eb34e88326a0f3484ec3c02621