### PR TITLE
Add localization support and translations

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'models.dart';
 import 'settings_page.dart';
@@ -48,12 +49,13 @@ class _GamePageState extends State<GamePage> {
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
     final game = app.current;
+    final l10n = AppLocalizations.of(context)!;
 
     if (game == null) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Судоку')),
-        body: const Center(
-          child: Text('Немає активної гри. Поверніться на головний екран.'),
+        appBar: AppBar(title: Text(l10n.gameScreenTitle)),
+        body: Center(
+          child: Text(l10n.noActiveGameMessage),
         ),
       );
     }
@@ -77,7 +79,7 @@ class _GamePageState extends State<GamePage> {
     });
 
     final difficulty =
-        (app.currentDifficulty ?? app.featuredStatsDifficulty).title;
+        (app.currentDifficulty ?? app.featuredStatsDifficulty).title(l10n);
 
     return Scaffold(
       body: SafeArea(
@@ -151,6 +153,7 @@ class _GamePageState extends State<GamePage> {
       context: context,
       barrierDismissible: false,
       builder: (context) {
+        final l10n = AppLocalizations.of(context)!;
         return Dialog(
           backgroundColor: Colors.white,
           shape: RoundedRectangleBorder(
@@ -173,16 +176,16 @@ class _GamePageState extends State<GamePage> {
                   child: const Icon(Icons.emoji_events, color: Colors.white, size: 36),
                 ),
                 const SizedBox(height: 18),
-                const Text(
-                  'Вітаємо!',
-                  style: TextStyle(
+                Text(
+                  l10n.victoryTitle,
+                  style: const TextStyle(
                     fontSize: 22,
                     fontWeight: FontWeight.w700,
                   ),
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Головоломку розв’язано за ${_formatTime(elapsedMs)}.',
+                  l10n.victoryMessage(_formatTime(elapsedMs)),
                   textAlign: TextAlign.center,
                   style: const TextStyle(
                     color: Color(0xFF6D7392),
@@ -198,7 +201,7 @@ class _GamePageState extends State<GamePage> {
                           Navigator.pop(context);
                           Navigator.pop(context);
                         },
-                        child: const Text('На головну'),
+                        child: Text(l10n.backToHome),
                       ),
                     ),
                     const SizedBox(width: 12),
@@ -223,7 +226,7 @@ class _GamePageState extends State<GamePage> {
                             borderRadius: BorderRadius.circular(16),
                           ),
                         ),
-                        child: const Text('Ще одну'),
+                        child: Text(l10n.playAnother),
                       ),
                     ),
                   ],
@@ -241,6 +244,7 @@ class _GamePageState extends State<GamePage> {
       context: context,
       barrierDismissible: false,
       builder: (context) {
+        final l10n = AppLocalizations.of(context)!;
         return Dialog(
           insetPadding: const EdgeInsets.symmetric(horizontal: 36),
           backgroundColor: Colors.white,
@@ -264,18 +268,18 @@ class _GamePageState extends State<GamePage> {
                   child: const Icon(Icons.favorite, color: Colors.white, size: 40),
                 ),
                 const SizedBox(height: 18),
-                const Text(
-                  'Ви втратили всі серця',
-                  style: TextStyle(
+                Text(
+                  l10n.outOfLivesTitle,
+                  style: const TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.w700,
                   ),
                 ),
                 const SizedBox(height: 8),
-                const Text(
-                  'Відновіть 1 червоне серце, щоб продовжити гру.',
+                Text(
+                  l10n.outOfLivesDescription,
                   textAlign: TextAlign.center,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: Color(0xFF6D7392),
                   ),
                 ),
@@ -292,12 +296,12 @@ class _GamePageState extends State<GamePage> {
                         borderRadius: BorderRadius.circular(18),
                       ),
                     ),
-                    child: const Text('Відновити 1 червоне серце'),
+                    child: Text(l10n.restoreLifeAction),
                   ),
                 ),
                 TextButton(
                   onPressed: () => Navigator.pop(context, false),
-                  child: const Text('Відмовлятися'),
+                  child: Text(l10n.cancelAction),
                 ),
               ],
             ),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'game_page.dart';
 import 'models.dart';
@@ -51,21 +52,22 @@ class _BottomNavBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return BottomNavigationBar(
       currentIndex: index,
       onTap: onChanged,
-      items: const [
+      items: [
         BottomNavigationBarItem(
-          icon: Icon(Icons.home_rounded),
-          label: 'Головна',
+          icon: const Icon(Icons.home_rounded),
+          label: l10n.navHome,
         ),
         BottomNavigationBarItem(
-          icon: Icon(Icons.calendar_month_rounded),
-          label: 'Щоденний виклик',
+          icon: const Icon(Icons.calendar_month_rounded),
+          label: l10n.navDaily,
         ),
         BottomNavigationBarItem(
-          icon: Icon(Icons.bar_chart_rounded),
-          label: 'Статистика',
+          icon: const Icon(Icons.bar_chart_rounded),
+          label: l10n.navStats,
         ),
       ],
     );
@@ -81,6 +83,7 @@ class _HomeTab extends StatelessWidget {
     final theme = Theme.of(context);
     final difficulty = app.featuredStatsDifficulty;
     final stats = app.statsFor(difficulty);
+    final l10n = AppLocalizations.of(context)!;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
@@ -100,7 +103,7 @@ class _HomeTab extends StatelessWidget {
           ),
           const SizedBox(height: 32),
           Text(
-            'Судоку Майстер',
+            l10n.appTitle,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w700,
               letterSpacing: -0.5,
@@ -122,6 +125,7 @@ class _HomeTab extends StatelessWidget {
 
   Future<void> _openDifficultySheet(BuildContext context) async {
     final app = context.read<AppState>();
+    final l10n = AppLocalizations.of(context)!;
     final difficulty = await showModalBottomSheet<Difficulty>(
       context: context,
       backgroundColor: Colors.white,
@@ -131,6 +135,7 @@ class _HomeTab extends StatelessWidget {
       builder: (context) {
         final items = Difficulty.values;
         final selected = app.featuredStatsDifficulty;
+        final sheetL10n = AppLocalizations.of(context)!;
 
         return Padding(
           padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
@@ -147,7 +152,7 @@ class _HomeTab extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               Text(
-                'Виберіть складність',
+                sheetL10n.selectDifficultyTitle,
                 style: Theme.of(context).textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w700,
                     ),
@@ -156,7 +161,7 @@ class _HomeTab extends StatelessWidget {
               Align(
                 alignment: Alignment.centerLeft,
                 child: Text(
-                  'Щоденний виклик',
+                  sheetL10n.selectDifficultyDailyChallenge,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: const Color(0xFF79819C),
                       ),
@@ -164,8 +169,8 @@ class _HomeTab extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               _DifficultyTile(
-                title: 'Щоденне виклик',
-                rankLabel: 'Ранг 1',
+                title: sheetL10n.navDaily,
+                rankLabel: sheetL10n.rankLabel(1),
                 progress: '—',
                 isActive: false,
                 onTap: () => Navigator.pop(context, Difficulty.beginner),
@@ -180,8 +185,8 @@ class _HomeTab extends StatelessWidget {
                     final diff = items[index];
                     final stats = app.statsFor(diff);
                     return _DifficultyTile(
-                      title: diff.title,
-                      rankLabel: 'Ранг ${stats.rank}',
+                      title: diff.title(sheetL10n),
+                      rankLabel: sheetL10n.rankLabel(stats.rank),
                       progress: stats.progressText,
                       isActive: diff == selected,
                       onTap: () => Navigator.pop(context, diff),
@@ -291,31 +296,32 @@ class _ChallengeCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final formatter = DateFormat('d MMMM', 'uk');
+    final l10n = AppLocalizations.of(context)!;
+    final formatter = DateFormat('d MMMM', l10n.localeName);
     final today = formatter.format(DateTime.now());
 
     final cards = [
       _ChallengeCardData(
-        title: 'Щоденне виклик',
+        title: l10n.navDaily,
         subtitle: today,
-        buttonLabel: 'Грати',
+        buttonLabel: l10n.playAction,
         gradient: const [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
         icon: Icons.emoji_events,
         onPressed: () {},
       ),
       _ChallengeCardData(
-        title: 'Чемпіонат',
-        subtitle: 'Рахунок $championshipScore',
-        buttonLabel: 'Грати',
+        title: l10n.championshipTitle,
+        subtitle: l10n.championshipScore(championshipScore),
+        buttonLabel: l10n.playAction,
         gradient: const [Color(0xFFFFB2D0), Color(0xFFE55D87)],
         icon: Icons.workspace_premium_outlined,
         onPressed: () {},
         badge: '2G',
       ),
       _ChallengeCardData(
-        title: 'Битва',
-        subtitle: 'Win Rate ${battleWinRate}%',
-        buttonLabel: 'Почати',
+        title: l10n.battleTitle,
+        subtitle: l10n.battleWinRate(battleWinRate),
+        buttonLabel: l10n.startAction,
         gradient: const [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
         icon: Icons.sports_esports_outlined,
         onPressed: () {},
@@ -457,6 +463,7 @@ class _DailyChain extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
       decoration: BoxDecoration(
@@ -476,7 +483,7 @@ class _DailyChain extends StatelessWidget {
           const Icon(Icons.local_fire_department, color: Color(0xFFFF713B)),
           const SizedBox(width: 8),
           Text(
-            'Ланцюг днів',
+            l10n.dailyStreak,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   fontWeight: FontWeight.w600,
                 ),
@@ -518,6 +525,8 @@ class _ProgressCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final difficultyTitle = difficulty.title(l10n);
 
     return Container(
       width: double.infinity,
@@ -544,14 +553,14 @@ class _ProgressCard extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'Рівень ${stats.level} — ${difficulty.title}',
+                      l10n.levelHeading(stats.level, difficultyTitle),
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.w700,
                       ),
                     ),
                     const SizedBox(height: 6),
                     Text(
-                      '${stats.bestTimeText} — ${difficulty.title}',
+                      '${stats.bestTimeText} — $difficultyTitle',
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: const Color(0xFF6D7392),
                       ),
@@ -564,7 +573,7 @@ class _ProgressCard extends StatelessWidget {
           ),
           const SizedBox(height: 20),
           Text(
-            'Прогрес рангу',
+            l10n.rankProgress,
             style: theme.textTheme.labelLarge?.copyWith(
               color: const Color(0xFF8187A5),
             ),
@@ -587,7 +596,7 @@ class _ProgressCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                'Ранг ${stats.rank}',
+                l10n.rankLabel(stats.rank),
                 style: theme.textTheme.bodyMedium?.copyWith(
                   fontWeight: FontWeight.w600,
                 ),
@@ -613,9 +622,9 @@ class _ProgressCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(18),
                 ),
               ),
-              child: const Text(
-                'Нова гра',
-                style: TextStyle(
+              child: Text(
+                l10n.newGame,
+                style: const TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w700,
                 ),
@@ -737,7 +746,8 @@ class _DailyChallengesTab extends StatelessWidget {
     final today = DateTime.now();
     final startOfWeek = today.subtract(Duration(days: today.weekday - 1));
     final days = List.generate(7, (i) => startOfWeek.add(Duration(days: i)));
-    final formatter = DateFormat('E', 'uk');
+    final l10n = AppLocalizations.of(context)!;
+    final formatter = DateFormat('E', l10n.localeName);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
@@ -745,18 +755,18 @@ class _DailyChallengesTab extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Щоденний виклик',
+            l10n.navDaily,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w700,
             ),
           ),
           const SizedBox(height: 20),
           _DailyHeroCard(
-            dateLabel: DateFormat('d MMMM', 'uk').format(today),
+            dateLabel: DateFormat('d MMMM', l10n.localeName).format(today),
           ),
           const SizedBox(height: 28),
           Text(
-            'Тижневий прогрес',
+            l10n.weeklyProgress,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w600,
             ),
@@ -776,28 +786,28 @@ class _DailyChallengesTab extends StatelessWidget {
           ),
           const SizedBox(height: 32),
           Text(
-            'Нагороди',
+            l10n.rewardsTitle,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w600,
             ),
           ),
           const SizedBox(height: 12),
-          const _RewardTile(
+          _RewardTile(
             icon: Icons.favorite_outline,
-            title: 'Завершіть виклик без помилок',
-            reward: '+1 серце',
+            title: l10n.rewardNoMistakesTitle,
+            reward: l10n.rewardExtraHearts(1),
           ),
           const SizedBox(height: 12),
-          const _RewardTile(
+          _RewardTile(
             icon: Icons.emoji_events_outlined,
-            title: 'Закінчіть три виклики поспіль',
-            reward: 'Унікальний трофей',
+            title: l10n.rewardThreeInRowTitle,
+            reward: l10n.rewardUniqueTrophy,
           ),
           const SizedBox(height: 12),
-          const _RewardTile(
+          _RewardTile(
             icon: Icons.local_fire_department_outlined,
-            title: 'Підтримуйте серію 7 днів',
-            reward: '+50 зірок',
+            title: l10n.rewardSevenDayTitle,
+            reward: l10n.rewardStars(50),
           ),
         ],
       ),
@@ -812,6 +822,7 @@ class _DailyHeroCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
@@ -838,18 +849,18 @@ class _DailyHeroCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 18),
-          const Text(
-            'Сьогоднішня головоломка',
-            style: TextStyle(
+          Text(
+            l10n.todayPuzzle,
+            style: const TextStyle(
               color: Colors.white,
               fontSize: 22,
               fontWeight: FontWeight.w700,
             ),
           ),
           const SizedBox(height: 8),
-          const Text(
-            'Завершіть судоку, щоб зібрати додаткову нагороду та продовжити серію.',
-            style: TextStyle(
+          Text(
+            l10n.todayPuzzleDescription,
+            style: const TextStyle(
               color: Colors.white70,
               fontSize: 14,
             ),
@@ -867,9 +878,9 @@ class _DailyHeroCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(16),
                 ),
               ),
-              child: const Text(
-                'Продовжити',
-                style: TextStyle(fontWeight: FontWeight.w700),
+              child: Text(
+                l10n.continueAction,
+                style: const TextStyle(fontWeight: FontWeight.w700),
               ),
             ),
           ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "de",
+  "appTitle": "Sudoku Meister",
+  "navHome": "Startseite",
+  "navDaily": "Tägliche Herausforderung",
+  "navStats": "Statistiken",
+  "dailyStreak": "Tagesserie",
+  "selectDifficultyTitle": "Schwierigkeitsgrad wählen",
+  "selectDifficultyDailyChallenge": "Tägliche Herausforderung",
+  "playAction": "Spielen",
+  "championshipTitle": "Meisterschaft",
+  "championshipScore": "Punktestand {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "Duell",
+  "battleWinRate": "Siegquote {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "Starten",
+  "levelHeading": "Level {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "Rangfortschritt",
+  "rankLabel": "Rang {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "Neues Spiel",
+  "weeklyProgress": "Wochenfortschritt",
+  "rewardsTitle": "Belohnungen",
+  "rewardNoMistakesTitle": "Schließe die Herausforderung ohne Fehler ab",
+  "rewardExtraHearts": "+{count, plural, one {# Herz} other {# Herzen}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "Schließe drei Herausforderungen in Folge ab",
+  "rewardUniqueTrophy": "Einzigartige Trophäe",
+  "rewardSevenDayTitle": "Halte eine Serie von 7 Tagen",
+  "rewardStars": "+{count, plural, one {# Stern} other {# Sterne}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "Heutiges Rätsel",
+  "todayPuzzleDescription": "Löse das Sudoku, um eine zusätzliche Belohnung zu erhalten und deine Serie fortzusetzen.",
+  "continueAction": "Weiter",
+  "adMessage": "Anzeige: Finde versteckte Objekte! Jetzt spielen.",
+  "adPlay": "Spielen",
+  "undo": "Rückgängig",
+  "erase": "Löschen",
+  "autoNotes": "Auto-Notizen",
+  "statusOn": "AN",
+  "statusOff": "AUS",
+  "notes": "Notizen",
+  "hint": "Tipp",
+  "gameScreenTitle": "Sudoku",
+  "noActiveGameMessage": "Kein aktives Spiel. Kehre zum Startbildschirm zurück.",
+  "victoryTitle": "Glückwunsch!",
+  "victoryMessage": "Rätsel gelöst in {time}.",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "Start",
+  "playAnother": "Noch eins",
+  "outOfLivesTitle": "Keine Herzen mehr",
+  "outOfLivesDescription": "Stelle ein rotes Herz wieder her, um weiterzuspielen.",
+  "restoreLifeAction": "1 rotes Herz wiederherstellen",
+  "cancelAction": "Abbrechen",
+  "settingsTitle": "Einstellungen",
+  "themeSectionTitle": "Design",
+  "themeSystem": "System",
+  "themeLight": "Hell",
+  "themeDark": "Dunkel",
+  "languageSectionTitle": "Sprache",
+  "audioSectionTitle": "Sound & Musik",
+  "soundsEffectsLabel": "Soundeffekte",
+  "vibrationLabel": "Vibration",
+  "musicLabel": "Hintergrundmusik",
+  "miscSectionTitle": "Sonstiges",
+  "aboutApp": "Über",
+  "versionLabel": "Version {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "Statistiken",
+  "statsGamesSection": "Spiele",
+  "statsGamesStarted": "Gestartete Spiele",
+  "statsGamesWon": "Gewonnene Spiele",
+  "statsWinRate": "Siegquote",
+  "statsFlawless": "Fehlerfreie Abschlüsse",
+  "statsTimeSection": "Zeit",
+  "statsBestTime": "Beste Zeit",
+  "statsAverageTime": "Durchschnittszeit",
+  "statsStreakSection": "Serie",
+  "statsCurrentStreak": "Aktuelle Serie",
+  "statsBestStreak": "Beste Serie",
+  "difficultyBeginner": "Anfänger",
+  "difficultyBeginnerShort": "Anf.",
+  "difficultyNovice": "Neuling",
+  "difficultyNoviceShort": "Neu.",
+  "difficultyMedium": "Mittel",
+  "difficultyMediumShort": "Mit.",
+  "difficultyHigh": "Schwer",
+  "difficultyHighShort": "Schw.",
+  "difficultyExpert": "Experte",
+  "difficultyExpertShort": "Exp.",
+  "difficultyMaster": "Meister",
+  "difficultyMasterShort": "Meis."
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "en",
+  "appTitle": "Sudoku Master",
+  "navHome": "Home",
+  "navDaily": "Daily Challenge",
+  "navStats": "Statistics",
+  "dailyStreak": "Daily streak",
+  "selectDifficultyTitle": "Choose difficulty",
+  "selectDifficultyDailyChallenge": "Daily challenge",
+  "playAction": "Play",
+  "championshipTitle": "Championship",
+  "championshipScore": "Score {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "Battle",
+  "battleWinRate": "Win rate {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "Start",
+  "levelHeading": "Level {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "Rank progress",
+  "rankLabel": "Rank {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "New game",
+  "weeklyProgress": "Weekly progress",
+  "rewardsTitle": "Rewards",
+  "rewardNoMistakesTitle": "Finish the challenge without mistakes",
+  "rewardExtraHearts": "+{count, plural, one {# heart} other {# hearts}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "Complete three challenges in a row",
+  "rewardUniqueTrophy": "Unique trophy",
+  "rewardSevenDayTitle": "Maintain a 7-day streak",
+  "rewardStars": "+{count, plural, one {# star} other {# stars}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "Today's puzzle",
+  "todayPuzzleDescription": "Finish the sudoku to earn an extra reward and keep your streak alive.",
+  "continueAction": "Continue",
+  "adMessage": "Ad: Find hidden objects! Play now.",
+  "adPlay": "Play",
+  "undo": "Undo",
+  "erase": "Erase",
+  "autoNotes": "Auto notes",
+  "statusOn": "ON",
+  "statusOff": "OFF",
+  "notes": "Notes",
+  "hint": "Hint",
+  "gameScreenTitle": "Sudoku",
+  "noActiveGameMessage": "No active game. Return to the home screen.",
+  "victoryTitle": "Congratulations!",
+  "victoryMessage": "Puzzle solved in {time}.",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "Home",
+  "playAnother": "Play again",
+  "outOfLivesTitle": "You're out of hearts",
+  "outOfLivesDescription": "Restore one red heart to keep playing.",
+  "restoreLifeAction": "Restore 1 red heart",
+  "cancelAction": "Cancel",
+  "settingsTitle": "Settings",
+  "themeSectionTitle": "Theme",
+  "themeSystem": "System",
+  "themeLight": "Light",
+  "themeDark": "Dark",
+  "languageSectionTitle": "Language",
+  "audioSectionTitle": "Sound & music",
+  "soundsEffectsLabel": "Sound effects",
+  "vibrationLabel": "Vibration",
+  "musicLabel": "Background music",
+  "miscSectionTitle": "Other",
+  "aboutApp": "About",
+  "versionLabel": "Version {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "Statistics",
+  "statsGamesSection": "Games",
+  "statsGamesStarted": "Games started",
+  "statsGamesWon": "Games won",
+  "statsWinRate": "Win rate",
+  "statsFlawless": "Flawless finishes",
+  "statsTimeSection": "Time",
+  "statsBestTime": "Best time",
+  "statsAverageTime": "Average time",
+  "statsStreakSection": "Streak",
+  "statsCurrentStreak": "Current streak",
+  "statsBestStreak": "Best streak",
+  "difficultyBeginner": "Beginner",
+  "difficultyBeginnerShort": "Beg.",
+  "difficultyNovice": "Novice",
+  "difficultyNoviceShort": "Nov.",
+  "difficultyMedium": "Intermediate",
+  "difficultyMediumShort": "Int.",
+  "difficultyHigh": "Advanced",
+  "difficultyHighShort": "Adv.",
+  "difficultyExpert": "Expert",
+  "difficultyExpertShort": "Exp.",
+  "difficultyMaster": "Master",
+  "difficultyMasterShort": "Mst."
+}

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "fr",
+  "appTitle": "Sudoku Maître",
+  "navHome": "Accueil",
+  "navDaily": "Défi quotidien",
+  "navStats": "Statistiques",
+  "dailyStreak": "Série quotidienne",
+  "selectDifficultyTitle": "Choisissez la difficulté",
+  "selectDifficultyDailyChallenge": "Défi quotidien",
+  "playAction": "Jouer",
+  "championshipTitle": "Championnat",
+  "championshipScore": "Score {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "Duel",
+  "battleWinRate": "Taux de victoire {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "Commencer",
+  "levelHeading": "Niveau {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "Progression du rang",
+  "rankLabel": "Rang {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "Nouvelle partie",
+  "weeklyProgress": "Progression hebdomadaire",
+  "rewardsTitle": "Récompenses",
+  "rewardNoMistakesTitle": "Terminez le défi sans erreur",
+  "rewardExtraHearts": "+{count, plural, one {# cœur} other {# cœurs}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "Terminez trois défis d'affilée",
+  "rewardUniqueTrophy": "Trophée unique",
+  "rewardSevenDayTitle": "Maintenez une série de 7 jours",
+  "rewardStars": "+{count, plural, one {# étoile} other {# étoiles}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "Casse-tête du jour",
+  "todayPuzzleDescription": "Terminez le sudoku pour gagner une récompense supplémentaire et prolonger votre série.",
+  "continueAction": "Continuer",
+  "adMessage": "Annonce : Trouvez les objets cachés ! Jouez maintenant.",
+  "adPlay": "Jouer",
+  "undo": "Annuler",
+  "erase": "Effacer",
+  "autoNotes": "Notes auto",
+  "statusOn": "ACTIF",
+  "statusOff": "ARRÊT",
+  "notes": "Notes",
+  "hint": "Indice",
+  "gameScreenTitle": "Sudoku",
+  "noActiveGameMessage": "Aucune partie en cours. Revenez à l'écran d'accueil.",
+  "victoryTitle": "Félicitations !",
+  "victoryMessage": "Énigme résolue en {time}.",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "Accueil",
+  "playAnother": "Rejouer",
+  "outOfLivesTitle": "Plus de cœurs",
+  "outOfLivesDescription": "Restaurez un cœur rouge pour continuer.",
+  "restoreLifeAction": "Restaurer 1 cœur rouge",
+  "cancelAction": "Annuler",
+  "settingsTitle": "Paramètres",
+  "themeSectionTitle": "Thème",
+  "themeSystem": "Système",
+  "themeLight": "Clair",
+  "themeDark": "Sombre",
+  "languageSectionTitle": "Langue",
+  "audioSectionTitle": "Son & musique",
+  "soundsEffectsLabel": "Effets sonores",
+  "vibrationLabel": "Vibration",
+  "musicLabel": "Musique de fond",
+  "miscSectionTitle": "Autre",
+  "aboutApp": "À propos",
+  "versionLabel": "Version {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "Statistiques",
+  "statsGamesSection": "Parties",
+  "statsGamesStarted": "Parties lancées",
+  "statsGamesWon": "Parties gagnées",
+  "statsWinRate": "Taux de victoire",
+  "statsFlawless": "Fin sans erreur",
+  "statsTimeSection": "Temps",
+  "statsBestTime": "Meilleur temps",
+  "statsAverageTime": "Temps moyen",
+  "statsStreakSection": "Série",
+  "statsCurrentStreak": "Série actuelle",
+  "statsBestStreak": "Meilleure série",
+  "difficultyBeginner": "Débutant",
+  "difficultyBeginnerShort": "Déb.",
+  "difficultyNovice": "Novice",
+  "difficultyNoviceShort": "Nov.",
+  "difficultyMedium": "Intermédiaire",
+  "difficultyMediumShort": "Inter.",
+  "difficultyHigh": "Difficile",
+  "difficultyHighShort": "Diff.",
+  "difficultyExpert": "Expert",
+  "difficultyExpertShort": "Exp.",
+  "difficultyMaster": "Maître",
+  "difficultyMasterShort": "Maît."
+}

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "hi",
+  "appTitle": "सुडोकू मास्टर",
+  "navHome": "होम",
+  "navDaily": "दैनिक चुनौती",
+  "navStats": "आँकड़े",
+  "dailyStreak": "दैनिक श्रृंखला",
+  "selectDifficultyTitle": "कठिनाई चुनें",
+  "selectDifficultyDailyChallenge": "दैनिक चुनौती",
+  "playAction": "खेलें",
+  "championshipTitle": "चैम्पियनशिप",
+  "championshipScore": "स्कोर {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "बैटल",
+  "battleWinRate": "जीत दर {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "शुरू करें",
+  "levelHeading": "स्तर {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "रैंक प्रगति",
+  "rankLabel": "रैंक {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "नया खेल",
+  "weeklyProgress": "साप्ताहिक प्रगति",
+  "rewardsTitle": "इनाम",
+  "rewardNoMistakesTitle": "बिना गलती के चुनौती पूरी करें",
+  "rewardExtraHearts": "+{count, plural, one {# दिल} other {# दिल}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "लगातार तीन चुनौतियाँ पूरी करें",
+  "rewardUniqueTrophy": "विशेष ट्रॉफी",
+  "rewardSevenDayTitle": "7-दिन की श्रृंखला बनाए रखें",
+  "rewardStars": "+{count, plural, one {# तारा} other {# तारे}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "आज की पहेली",
+  "todayPuzzleDescription": "अतिरिक्त इनाम पाने और श्रृंखला बनाए रखने के लिए सुडोकू पूरा करें।",
+  "continueAction": "जारी रखें",
+  "adMessage": "विज्ञापन: छिपी वस्तुएँ खोजें! अभी खेलें।",
+  "adPlay": "खेलें",
+  "undo": "पूर्ववत् करें",
+  "erase": "मिटाएँ",
+  "autoNotes": "स्वचालित नोट्स",
+  "statusOn": "चालू",
+  "statusOff": "बंद",
+  "notes": "नोट्स",
+  "hint": "संकेत",
+  "gameScreenTitle": "सुडोकू",
+  "noActiveGameMessage": "कोई सक्रिय खेल नहीं। होम स्क्रीन पर लौटें।",
+  "victoryTitle": "बधाई!",
+  "victoryMessage": "{time} में पहेली हल हुई।",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "होम",
+  "playAnother": "फिर से खेलें",
+  "outOfLivesTitle": "दिल समाप्त",
+  "outOfLivesDescription": "खेल जारी रखने के लिए एक लाल दिल पुनर्स्थापित करें।",
+  "restoreLifeAction": "1 लाल दिल पुनर्स्थापित करें",
+  "cancelAction": "रद्द करें",
+  "settingsTitle": "सेटिंग्स",
+  "themeSectionTitle": "थीम",
+  "themeSystem": "सिस्टम",
+  "themeLight": "हल्का",
+  "themeDark": "गहरा",
+  "languageSectionTitle": "भाषा",
+  "audioSectionTitle": "ध्वनि और संगीत",
+  "soundsEffectsLabel": "ध्वनि प्रभाव",
+  "vibrationLabel": "कंपन",
+  "musicLabel": "पृष्ठभूमि संगीत",
+  "miscSectionTitle": "अन्य",
+  "aboutApp": "ऐप के बारे में",
+  "versionLabel": "संस्करण {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "आँकड़े",
+  "statsGamesSection": "खेल",
+  "statsGamesStarted": "शुरू किए गए खेल",
+  "statsGamesWon": "जीते गए खेल",
+  "statsWinRate": "जीत दर",
+  "statsFlawless": "बिना गलती की जीतें",
+  "statsTimeSection": "समय",
+  "statsBestTime": "सर्वश्रेष्ठ समय",
+  "statsAverageTime": "औसत समय",
+  "statsStreakSection": "श्रृंखला",
+  "statsCurrentStreak": "वर्तमान श्रृंखला",
+  "statsBestStreak": "सर्वश्रेष्ठ श्रृंखला",
+  "difficultyBeginner": "शुरुआती",
+  "difficultyBeginnerShort": "शुरु.",
+  "difficultyNovice": "नवागंतुक",
+  "difficultyNoviceShort": "नवा.",
+  "difficultyMedium": "मध्यम",
+  "difficultyMediumShort": "मध्.",
+  "difficultyHigh": "कठिन",
+  "difficultyHighShort": "कठि.",
+  "difficultyExpert": "विशेषज्ञ",
+  "difficultyExpertShort": "विशे.",
+  "difficultyMaster": "मास्टर",
+  "difficultyMasterShort": "मास्."
+}

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "ru",
+  "appTitle": "Судоку Мастер",
+  "navHome": "Главная",
+  "navDaily": "Ежедневный вызов",
+  "navStats": "Статистика",
+  "dailyStreak": "Серия дней",
+  "selectDifficultyTitle": "Выберите сложность",
+  "selectDifficultyDailyChallenge": "Ежедневный вызов",
+  "playAction": "Играть",
+  "championshipTitle": "Чемпионат",
+  "championshipScore": "Счёт {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "Битва",
+  "battleWinRate": "Процент побед {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "Начать",
+  "levelHeading": "Уровень {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "Прогресс ранга",
+  "rankLabel": "Ранг {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "Новая игра",
+  "weeklyProgress": "Недельный прогресс",
+  "rewardsTitle": "Награды",
+  "rewardNoMistakesTitle": "Пройдите вызов без ошибок",
+  "rewardExtraHearts": "+{count, plural, one {# сердце} few {# сердца} many {# сердец} other {# сердца}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "Выполните три вызова подряд",
+  "rewardUniqueTrophy": "Уникальный трофей",
+  "rewardSevenDayTitle": "Поддерживайте серию 7 дней",
+  "rewardStars": "+{count, plural, one {# звезда} few {# звезды} many {# звёзд} other {# звезды}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "Сегодняшняя головоломка",
+  "todayPuzzleDescription": "Решите судоку, чтобы получить дополнительную награду и продолжить серию.",
+  "continueAction": "Продолжить",
+  "adMessage": "Реклама: Найди скрытые объекты! Играй сейчас.",
+  "adPlay": "Играть",
+  "undo": "Отменить",
+  "erase": "Стереть",
+  "autoNotes": "Автозаметки",
+  "statusOn": "ВКЛ",
+  "statusOff": "ВЫКЛ",
+  "notes": "Заметки",
+  "hint": "Подсказка",
+  "gameScreenTitle": "Судоку",
+  "noActiveGameMessage": "Нет активной игры. Вернитесь на главный экран.",
+  "victoryTitle": "Поздравляем!",
+  "victoryMessage": "Головоломка решена за {time}.",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "На главную",
+  "playAnother": "Ещё одну",
+  "outOfLivesTitle": "Сердца закончились",
+  "outOfLivesDescription": "Восстановите одно красное сердце, чтобы продолжить игру.",
+  "restoreLifeAction": "Восстановить 1 красное сердце",
+  "cancelAction": "Отмена",
+  "settingsTitle": "Настройки",
+  "themeSectionTitle": "Тема",
+  "themeSystem": "Системная",
+  "themeLight": "Светлая",
+  "themeDark": "Тёмная",
+  "languageSectionTitle": "Язык",
+  "audioSectionTitle": "Звук и музыка",
+  "soundsEffectsLabel": "Звуковые эффекты",
+  "vibrationLabel": "Вибрация",
+  "musicLabel": "Фоновая музыка",
+  "miscSectionTitle": "Другое",
+  "aboutApp": "О приложении",
+  "versionLabel": "Версия {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "Статистика",
+  "statsGamesSection": "Игры",
+  "statsGamesStarted": "Начатые игры",
+  "statsGamesWon": "Выигранные игры",
+  "statsWinRate": "Процент побед",
+  "statsFlawless": "Победы без ошибок",
+  "statsTimeSection": "Время",
+  "statsBestTime": "Лучшее время",
+  "statsAverageTime": "Среднее время",
+  "statsStreakSection": "Серия",
+  "statsCurrentStreak": "Текущая серия",
+  "statsBestStreak": "Лучшая серия",
+  "difficultyBeginner": "Новичок",
+  "difficultyBeginnerShort": "Нов.",
+  "difficultyNovice": "Любитель",
+  "difficultyNoviceShort": "Люб.",
+  "difficultyMedium": "Средний",
+  "difficultyMediumShort": "Ср.",
+  "difficultyHigh": "Сложный",
+  "difficultyHighShort": "Слж.",
+  "difficultyExpert": "Эксперт",
+  "difficultyExpertShort": "Эксп.",
+  "difficultyMaster": "Мастер",
+  "difficultyMasterShort": "Маст."
+}

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "uk",
+  "appTitle": "Судоку Майстер",
+  "navHome": "Головна",
+  "navDaily": "Щоденний виклик",
+  "navStats": "Статистика",
+  "dailyStreak": "Ланцюг днів",
+  "selectDifficultyTitle": "Виберіть складність",
+  "selectDifficultyDailyChallenge": "Щоденний виклик",
+  "playAction": "Грати",
+  "championshipTitle": "Чемпіонат",
+  "championshipScore": "Рахунок {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "Битва",
+  "battleWinRate": "Відсоток перемог {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "Почати",
+  "levelHeading": "Рівень {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "Прогрес рангу",
+  "rankLabel": "Ранг {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "Нова гра",
+  "weeklyProgress": "Тижневий прогрес",
+  "rewardsTitle": "Нагороди",
+  "rewardNoMistakesTitle": "Завершіть виклик без помилок",
+  "rewardExtraHearts": "+{count, plural, one {# серце} few {# серця} many {# сердець} other {# серця}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "Виконайте три виклики поспіль",
+  "rewardUniqueTrophy": "Унікальний трофей",
+  "rewardSevenDayTitle": "Підтримуйте серію 7 днів",
+  "rewardStars": "+{count, plural, one {# зірка} few {# зірки} many {# зірок} other {# зірки}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "Сьогоднішня головоломка",
+  "todayPuzzleDescription": "Завершіть судоку, щоб отримати додаткову нагороду та продовжити серію.",
+  "continueAction": "Продовжити",
+  "adMessage": "Реклама: Знайди приховані об'єкти! Грай зараз.",
+  "adPlay": "Грати",
+  "undo": "Скасувати",
+  "erase": "Стерти",
+  "autoNotes": "Автоматичні нотатки",
+  "statusOn": "УВІМК",
+  "statusOff": "ВИМК",
+  "notes": "Нотатки",
+  "hint": "Підказка",
+  "gameScreenTitle": "Судоку",
+  "noActiveGameMessage": "Немає активної гри. Поверніться на головний екран.",
+  "victoryTitle": "Вітаємо!",
+  "victoryMessage": "Головоломку розв'язано за {time}.",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "На головну",
+  "playAnother": "Ще одну",
+  "outOfLivesTitle": "Ви втратили всі серця",
+  "outOfLivesDescription": "Відновіть одне червоне серце, щоб продовжити гру.",
+  "restoreLifeAction": "Відновити 1 червоне серце",
+  "cancelAction": "Скасувати",
+  "settingsTitle": "Налаштування",
+  "themeSectionTitle": "Тема",
+  "themeSystem": "Системна",
+  "themeLight": "Світла",
+  "themeDark": "Темна",
+  "languageSectionTitle": "Мова",
+  "audioSectionTitle": "Звуки та музика",
+  "soundsEffectsLabel": "Звукові ефекти",
+  "vibrationLabel": "Вібрація",
+  "musicLabel": "Фонова музика",
+  "miscSectionTitle": "Інше",
+  "aboutApp": "Про застосунок",
+  "versionLabel": "Версія {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "Статистика",
+  "statsGamesSection": "Ігри",
+  "statsGamesStarted": "Розпочаті ігри",
+  "statsGamesWon": "Виграні ігри",
+  "statsWinRate": "Відсоток перемог",
+  "statsFlawless": "Безпомилкові завершення",
+  "statsTimeSection": "Час",
+  "statsBestTime": "Найкращий час",
+  "statsAverageTime": "Середній час",
+  "statsStreakSection": "Серія",
+  "statsCurrentStreak": "Поточна серія",
+  "statsBestStreak": "Найкраща серія",
+  "difficultyBeginner": "Початківець",
+  "difficultyBeginnerShort": "Поч.",
+  "difficultyNovice": "Новачок",
+  "difficultyNoviceShort": "Нов.",
+  "difficultyMedium": "Середній",
+  "difficultyMediumShort": "Сер.",
+  "difficultyHigh": "Високий",
+  "difficultyHighShort": "Вис.",
+  "difficultyExpert": "Експерт",
+  "difficultyExpertShort": "Експ.",
+  "difficultyMaster": "Майстер",
+  "difficultyMasterShort": "Майст."
+}

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -1,0 +1,154 @@
+{
+  "@@locale": "zh",
+  "appTitle": "数独大师",
+  "navHome": "首页",
+  "navDaily": "每日挑战",
+  "navStats": "统计",
+  "dailyStreak": "连续天数",
+  "selectDifficultyTitle": "选择难度",
+  "selectDifficultyDailyChallenge": "每日挑战",
+  "playAction": "游玩",
+  "championshipTitle": "锦标赛",
+  "championshipScore": "得分 {score}",
+  "@championshipScore": {
+    "placeholders": {
+      "score": {
+        "type": "int"
+      }
+    }
+  },
+  "battleTitle": "对战",
+  "battleWinRate": "胜率 {percent}%",
+  "@battleWinRate": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "startAction": "开始",
+  "levelHeading": "等级 {level} — {difficulty}",
+  "@levelHeading": {
+    "placeholders": {
+      "level": {
+        "type": "int"
+      },
+      "difficulty": {
+        "type": "String"
+      }
+    }
+  },
+  "rankProgress": "段位进度",
+  "rankLabel": "段位 {rank}",
+  "@rankLabel": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      }
+    }
+  },
+  "newGame": "新游戏",
+  "weeklyProgress": "每周进度",
+  "rewardsTitle": "奖励",
+  "rewardNoMistakesTitle": "无错误完成挑战",
+  "rewardExtraHearts": "+{count, plural, other {# 颗心}}",
+  "@rewardExtraHearts": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "rewardThreeInRowTitle": "连续完成三次挑战",
+  "rewardUniqueTrophy": "专属奖杯",
+  "rewardSevenDayTitle": "保持 7 天连胜",
+  "rewardStars": "+{count, plural, other {# 颗星}}",
+  "@rewardStars": {
+    "placeholders": {
+      "count": {
+        "type": "num"
+      }
+    }
+  },
+  "todayPuzzle": "今日谜题",
+  "todayPuzzleDescription": "完成数独即可获得额外奖励并保持连胜。",
+  "continueAction": "继续",
+  "adMessage": "广告：寻找隐藏物品！立即游玩。",
+  "adPlay": "游玩",
+  "undo": "撤销",
+  "erase": "清除",
+  "autoNotes": "自动笔记",
+  "statusOn": "开启",
+  "statusOff": "关闭",
+  "notes": "笔记",
+  "hint": "提示",
+  "gameScreenTitle": "数独",
+  "noActiveGameMessage": "没有进行中的游戏。返回主界面。",
+  "victoryTitle": "恭喜！",
+  "victoryMessage": "在 {time} 内完成谜题。",
+  "@victoryMessage": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "backToHome": "首页",
+  "playAnother": "再来一局",
+  "outOfLivesTitle": "心已用完",
+  "outOfLivesDescription": "恢复一个红心以继续游戏。",
+  "restoreLifeAction": "恢复 1 个红心",
+  "cancelAction": "取消",
+  "settingsTitle": "设置",
+  "themeSectionTitle": "主题",
+  "themeSystem": "跟随系统",
+  "themeLight": "浅色",
+  "themeDark": "深色",
+  "languageSectionTitle": "语言",
+  "audioSectionTitle": "声音与音乐",
+  "soundsEffectsLabel": "音效",
+  "vibrationLabel": "震动",
+  "musicLabel": "背景音乐",
+  "miscSectionTitle": "其他",
+  "aboutApp": "关于",
+  "versionLabel": "版本 {version}",
+  "@versionLabel": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutLegalese": "© 2025 Sudoku Inc.",
+  "languageEnglish": "English",
+  "languageRussian": "Русский",
+  "languageUkrainian": "Українська",
+  "languageGerman": "Deutsch",
+  "languageFrench": "Français",
+  "languageChinese": "中文",
+  "languageHindi": "हिन्दी",
+  "statsTitle": "统计",
+  "statsGamesSection": "对局",
+  "statsGamesStarted": "开始的对局",
+  "statsGamesWon": "获胜的对局",
+  "statsWinRate": "胜率",
+  "statsFlawless": "完美通关",
+  "statsTimeSection": "时间",
+  "statsBestTime": "最佳时间",
+  "statsAverageTime": "平均时间",
+  "statsStreakSection": "连胜",
+  "statsCurrentStreak": "当前连胜",
+  "statsBestStreak": "最高连胜",
+  "difficultyBeginner": "入门",
+  "difficultyBeginnerShort": "入门",
+  "difficultyNovice": "新手",
+  "difficultyNoviceShort": "新手",
+  "difficultyMedium": "中等",
+  "difficultyMediumShort": "中等",
+  "difficultyHigh": "困难",
+  "difficultyHighShort": "困难",
+  "difficultyExpert": "专家",
+  "difficultyExpertShort": "专家",
+  "difficultyMaster": "大师",
+  "difficultyMasterShort": "大师"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'home_screen.dart';
 import 'models.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await initializeDateFormatting('uk');
+  const locales = ['en', 'ru', 'uk', 'de', 'fr', 'zh', 'hi'];
+  await Future.wait(locales.map(initializeDateFormatting));
 
   runApp(
     ChangeNotifierProvider(
@@ -47,8 +50,15 @@ class SudokuApp extends StatelessWidget {
     );
 
     return MaterialApp(
-      title: 'Sudoku Master',
-      locale: const Locale('uk'),
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
+      locale: app.lang.locale,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       themeMode: switch (app.theme) {
         AppTheme.system => ThemeMode.system,
         AppTheme.light => ThemeMode.light,

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'puzzles.dart';
@@ -11,24 +12,24 @@ import 'puzzles.dart';
 enum Difficulty { beginner, novice, medium, high, expert, master }
 
 extension DifficultyX on Difficulty {
-  /// Человекочитаемое название уровня сложности (украинский язык).
-  String get title => switch (this) {
-        Difficulty.beginner => 'Початківець',
-        Difficulty.novice => 'Новачок',
-        Difficulty.medium => 'Середній',
-        Difficulty.high => 'Високий',
-        Difficulty.expert => 'Експерт',
-        Difficulty.master => 'Майстер',
+  /// Человекочитаемое название уровня сложности.
+  String title(AppLocalizations l10n) => switch (this) {
+        Difficulty.beginner => l10n.difficultyBeginner,
+        Difficulty.novice => l10n.difficultyNovice,
+        Difficulty.medium => l10n.difficultyMedium,
+        Difficulty.high => l10n.difficultyHigh,
+        Difficulty.expert => l10n.difficultyExpert,
+        Difficulty.master => l10n.difficultyMaster,
       };
 
   /// Короткая подпись, которая хорошо подходит для бейджей и карточек.
-  String get shortLabel => switch (this) {
-        Difficulty.beginner => 'Поч.',
-        Difficulty.novice => 'Нов.',
-        Difficulty.medium => 'Сер.',
-        Difficulty.high => 'Вис.',
-        Difficulty.expert => 'Експ.',
-        Difficulty.master => 'Майст.',
+  String shortLabel(AppLocalizations l10n) => switch (this) {
+        Difficulty.beginner => l10n.difficultyBeginnerShort,
+        Difficulty.novice => l10n.difficultyNoviceShort,
+        Difficulty.medium => l10n.difficultyMediumShort,
+        Difficulty.high => l10n.difficultyHighShort,
+        Difficulty.expert => l10n.difficultyExpertShort,
+        Difficulty.master => l10n.difficultyMasterShort,
       };
 }
 
@@ -39,14 +40,29 @@ enum AppTheme { system, light, dark }
 enum AppLanguage { en, ru, uk, de, fr, zh, hi }
 
 extension AppLanguageX on AppLanguage {
-  String get nameLocal => switch (this) {
-        AppLanguage.en => 'English',
-        AppLanguage.ru => 'Русский',
-        AppLanguage.uk => 'Українська',
-        AppLanguage.de => 'Deutsch',
-        AppLanguage.fr => 'Français',
-        AppLanguage.zh => '中文',
-        AppLanguage.hi => 'हिन्दी',
+  /// Локаль, соответствующая языку приложения.
+  Locale get locale => switch (this) {
+        AppLanguage.en => const Locale('en'),
+        AppLanguage.ru => const Locale('ru'),
+        AppLanguage.uk => const Locale('uk'),
+        AppLanguage.de => const Locale('de'),
+        AppLanguage.fr => const Locale('fr'),
+        AppLanguage.zh => const Locale('zh'),
+        AppLanguage.hi => const Locale('hi'),
+      };
+
+  /// Строковое представление локали (подходит для форматирования дат).
+  String get localeCode => locale.languageCode;
+
+  /// Название языка для отображения в настройках.
+  String displayName(AppLocalizations l10n) => switch (this) {
+        AppLanguage.en => l10n.languageEnglish,
+        AppLanguage.ru => l10n.languageRussian,
+        AppLanguage.uk => l10n.languageUkrainian,
+        AppLanguage.de => l10n.languageGerman,
+        AppLanguage.fr => l10n.languageFrench,
+        AppLanguage.zh => l10n.languageChinese,
+        AppLanguage.hi => l10n.languageHindi,
       };
 }
 

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'models.dart';
+
+const _appVersion = '1.0.0';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -9,18 +12,19 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
+    final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Настройки"),
+        title: Text(l10n.settingsTitle),
         centerTitle: true,
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _sectionTitle("Тема приложения"),
+          _sectionTitle(l10n.themeSectionTitle),
           RadioListTile<AppTheme>(
-            title: const Text("Системная"),
+            title: Text(l10n.themeSystem),
             value: AppTheme.system,
             groupValue: app.theme,
             onChanged: (v) {
@@ -30,7 +34,7 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           RadioListTile<AppTheme>(
-            title: const Text("Светлая"),
+            title: Text(l10n.themeLight),
             value: AppTheme.light,
             groupValue: app.theme,
             onChanged: (v) {
@@ -40,7 +44,7 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           RadioListTile<AppTheme>(
-            title: const Text("Тёмная"),
+            title: Text(l10n.themeDark),
             value: AppTheme.dark,
             groupValue: app.theme,
             onChanged: (v) {
@@ -51,10 +55,10 @@ class SettingsPage extends StatelessWidget {
           ),
           const Divider(height: 32),
 
-          _sectionTitle("Язык"),
+          _sectionTitle(l10n.languageSectionTitle),
           ...AppLanguage.values.map(
                 (lang) => RadioListTile<AppLanguage>(
-              title: Text(lang.nameLocal),
+              title: Text(lang.displayName(l10n)),
               value: lang,
               groupValue: app.lang,
               onChanged: (v) {
@@ -66,38 +70,38 @@ class SettingsPage extends StatelessWidget {
           ),
           const Divider(height: 32),
 
-          _sectionTitle("Звуки и музыка"),
+          _sectionTitle(l10n.audioSectionTitle),
           SwitchListTile(
-            title: const Text("Звуковые эффекты"),
+            title: Text(l10n.soundsEffectsLabel),
             value: app.soundsEnabled,
             onChanged: (v) => app.toggleSounds(v),
             secondary: const Icon(Icons.volume_up),
           ),
           SwitchListTile(
-            title: const Text("Вибрация"),
+            title: Text(l10n.vibrationLabel),
             value: app.vibrationEnabled,
             onChanged: (v) => app.toggleVibration(v),
             secondary: const Icon(Icons.vibration),
           ),
           SwitchListTile(
-            title: const Text("Фоновая музыка"),
+            title: Text(l10n.musicLabel),
             value: app.musicEnabled,
             onChanged: (v) => app.toggleMusic(v),
             secondary: const Icon(Icons.music_note),
           ),
           const Divider(height: 32),
 
-          _sectionTitle("Разное"),
+          _sectionTitle(l10n.miscSectionTitle),
           ListTile(
             leading: const Icon(Icons.info_outline),
-            title: const Text("О приложении"),
-            subtitle: const Text("Версия 1.0.0"),
+            title: Text(l10n.aboutApp),
+            subtitle: Text(l10n.versionLabel(_appVersion)),
             onTap: () {
               showAboutDialog(
                 context: context,
-                applicationName: "Sudoku Deluxe",
-                applicationVersion: "1.0.0",
-                applicationLegalese: "© 2025 Sudoku Inc.",
+                applicationName: l10n.appTitle,
+                applicationVersion: _appVersion,
+                applicationLegalese: l10n.aboutLegalese,
               );
             },
           ),

--- a/lib/stats_page.dart
+++ b/lib/stats_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'models.dart';
 
@@ -25,6 +26,7 @@ class _StatsTabState extends State<StatsTab> {
     final stats = app.statsFor(_selected);
     final theme = Theme.of(context);
     final primary = theme.colorScheme.primary;
+    final l10n = AppLocalizations.of(context)!;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
@@ -32,7 +34,7 @@ class _StatsTabState extends State<StatsTab> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Статистика',
+            l10n.statsTitle,
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w700,
             ),
@@ -44,66 +46,66 @@ class _StatsTabState extends State<StatsTab> {
           ),
           const SizedBox(height: 24),
           _StatsSection(
-            title: 'Ігри',
+            title: l10n.statsGamesSection,
             rows: [
               _StatRowData(
                 icon: Icons.play_circle_outline,
                 color: primary,
-                label: 'Початі ігри',
+                label: l10n.statsGamesStarted,
                 value: stats.gamesStarted.toString(),
               ),
               _StatRowData(
                 icon: Icons.emoji_events_outlined,
                 color: const Color(0xFF6ACB8A),
-                label: 'Виграні ігри',
+                label: l10n.statsGamesWon,
                 value: stats.gamesWon.toString(),
               ),
               _StatRowData(
                 icon: Icons.pie_chart_outline,
                 color: const Color(0xFFE8736D),
-                label: 'Відсоток перемог',
+                label: l10n.statsWinRate,
                 value: stats.winRateText,
               ),
               _StatRowData(
                 icon: Icons.shield_moon_outlined,
                 color: const Color(0xFFFFB347),
-                label: 'Завершення без помилок',
+                label: l10n.statsFlawless,
                 value: stats.flawlessWins.toString(),
               ),
             ],
           ),
           const SizedBox(height: 24),
           _StatsSection(
-            title: 'Час',
+            title: l10n.statsTimeSection,
             rows: [
               _StatRowData(
                 icon: Icons.timer_outlined,
                 color: primary,
-                label: 'Кращий час',
+                label: l10n.statsBestTime,
                 value: stats.bestTimeText,
               ),
               _StatRowData(
                 icon: Icons.hourglass_bottom,
                 color: const Color(0xFF6D7392),
-                label: 'Середній час',
+                label: l10n.statsAverageTime,
                 value: stats.averageTimeText,
               ),
             ],
           ),
           const SizedBox(height: 24),
           _StatsSection(
-            title: 'Серія',
+            title: l10n.statsStreakSection,
             rows: [
               _StatRowData(
                 icon: Icons.bolt_outlined,
                 color: const Color(0xFFFB923C),
-                label: 'Поточна серія',
+                label: l10n.statsCurrentStreak,
                 value: stats.currentStreak.toString(),
               ),
               _StatRowData(
                 icon: Icons.auto_graph_outlined,
                 color: primary,
-                label: 'Найкраща серія',
+                label: l10n.statsBestStreak,
                 value: stats.bestStreak.toString(),
               ),
             ],
@@ -127,13 +129,14 @@ class _DifficultySelector extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final primary = theme.colorScheme.primary;
+    final l10n = AppLocalizations.of(context)!;
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       children: [
         for (final diff in Difficulty.values)
           ChoiceChip(
-            label: Text(diff.title),
+            label: Text(diff.title(l10n)),
             selected: diff == selected,
             onSelected: (_) => onChanged(diff),
             selectedColor: primary,

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../models.dart';
 
@@ -31,6 +32,7 @@ class _ActionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
@@ -49,33 +51,33 @@ class _ActionRow extends StatelessWidget {
         children: [
           _ActionButton(
             icon: Icons.undo_rounded,
-            label: 'Скасувати',
+            label: l10n.undo,
             onTap: app.undoMove,
           ),
           _ActionButton(
             icon: Icons.backspace_outlined,
-            label: 'Стерти',
+            label: l10n.erase,
             onTap: app.eraseCell,
           ),
           _ActionButton(
             icon: Icons.auto_awesome,
-            label: 'Автоматичні нотатки',
+            label: l10n.autoNotes,
             onTap: app.toggleAutoNotes,
-            chipLabel: app.autoNotes ? 'УВІМК' : 'ВИМК',
+            chipLabel: app.autoNotes ? l10n.statusOn : l10n.statusOff,
             chipColor:
                 app.autoNotes ? const Color(0xFF3B82F6) : theme.disabledColor,
           ),
           _ActionButton(
             icon: Icons.edit_note,
-            label: 'Нотатки',
+            label: l10n.notes,
             onTap: app.toggleNotesMode,
-            chipLabel: app.notesMode ? 'УВІМК' : 'ВИМК',
+            chipLabel: app.notesMode ? l10n.statusOn : l10n.statusOff,
             chipColor:
                 app.notesMode ? const Color(0xFF3B82F6) : theme.disabledColor,
           ),
           _ActionButton(
             icon: Icons.lightbulb_outline,
-            label: 'Підказка',
+            label: l10n.hint,
             onTap: app.hintsLeft > 0 ? app.useHint : null,
             chipLabel: app.hintsLeft.toString(),
             chipColor: app.hintsLeft > 0
@@ -268,6 +270,7 @@ class _AdBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
@@ -278,21 +281,21 @@ class _AdBanner extends StatelessWidget {
         ),
       ),
       child: Row(
-        children: const [
-          Icon(Icons.play_circle_fill, color: Colors.white),
-          SizedBox(width: 12),
+        children: [
+          const Icon(Icons.play_circle_fill, color: Colors.white),
+          const SizedBox(width: 12),
           Expanded(
             child: Text(
-              'Реклама: Знайди приховані об’єкти! Грай зараз.',
-              style: TextStyle(
+              l10n.adMessage,
+              style: const TextStyle(
                 color: Colors.white,
                 fontWeight: FontWeight.w600,
               ),
             ),
           ),
           Text(
-            'Play',
-            style: TextStyle(
+            l10n.adPlay,
+            style: const TextStyle(
               color: Colors.white,
               fontWeight: FontWeight.w700,
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_localizations:
+    sdk: flutter
   provider: ^6.1.5+1
   shared_preferences: ^2.5.3
   intl: ^0.19.0
@@ -59,6 +61,7 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  generate: true
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,13 +6,18 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:sudoku2/main.dart';
 import 'package:sudoku2/models.dart';
 
 void main() {
-  testWidgets('Главный экран отображает список уровней', (tester) async {
+  testWidgets('Домашний экран отображает основные секции', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await initializeDateFormatting('uk');
+
     await tester.pumpWidget(
       ChangeNotifierProvider(
         create: (_) => AppState(),
@@ -20,7 +25,9 @@ void main() {
       ),
     );
 
-    expect(find.text('Выберите уровень сложности:'), findsOneWidget);
-    expect(find.text('Новичок'), findsOneWidget);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Судоку Майстер'), findsOneWidget);
+    expect(find.text('Щоденний виклик'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- add Flutter localization dependencies and ARB translation files for English, Russian, Ukrainian, German, French, Chinese, and Hindi
- replace hard-coded UI text with AppLocalizations lookups and locale-aware formatting across screens and widgets
- update the widget test to validate the localized home screen copy

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca929543048326a4e95da91260af9d