### PR TITLE
Add continue game flow and clean home screen

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -116,6 +116,12 @@ class _HomeTab extends StatelessWidget {
             difficulty: difficulty,
             stats: stats,
             onNewGame: () => _openDifficultySheet(context),
+            onContinue: app.hasUnfinishedGame
+                ? () => Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const GamePage()),
+                    )
+                : null,
             heartBonus: app.heartBonus,
           ),
         ],
@@ -218,36 +224,16 @@ class _TopBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        Container(
-          width: 48,
-          height: 48,
-          decoration: const BoxDecoration(
-            shape: BoxShape.circle,
-            gradient: LinearGradient(
-              colors: [Color(0xFF3B82F6), Color(0xFF60A5FA)],
-            ),
-          ),
-          child: const Icon(Icons.person_outline, color: Colors.white),
+        _CircleButton(
+          icon: Icons.leaderboard_outlined,
+          onTap: () {},
         ),
-        Row(
-          children: [
-            _CircleButton(
-              icon: Icons.emoji_events_outlined,
-              onTap: () {},
-            ),
-            const SizedBox(width: 12),
-            _CircleButton(
-              icon: Icons.leaderboard_outlined,
-              onTap: () {},
-            ),
-            const SizedBox(width: 12),
-            _CircleButton(
-              icon: Icons.settings_outlined,
-              onTap: onSettingsTap,
-            ),
-          ],
+        const SizedBox(width: 12),
+        _CircleButton(
+          icon: Icons.settings_outlined,
+          onTap: onSettingsTap,
         ),
       ],
     );
@@ -513,12 +499,14 @@ class _ProgressCard extends StatelessWidget {
   final Difficulty difficulty;
   final DifficultyStats stats;
   final VoidCallback onNewGame;
+  final VoidCallback? onContinue;
   final int heartBonus;
 
   const _ProgressCard({
     required this.difficulty,
     required this.stats,
     required this.onNewGame,
+    this.onContinue,
     required this.heartBonus,
   });
 
@@ -610,6 +598,30 @@ class _ProgressCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 24),
+          if (onContinue != null) ...[
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: onContinue,
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: const Color(0xFF3B82F6),
+                  side: const BorderSide(color: Color(0xFF3B82F6)),
+                  padding: const EdgeInsets.symmetric(vertical: 18),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(18),
+                  ),
+                ),
+                child: Text(
+                  l10n.continueGame,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
           SizedBox(
             width: double.infinity,
             child: ElevatedButton(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "Neues Spiel",
+  "continueGame": "Spiel fortsetzen",
   "weeklyProgress": "Wochenfortschritt",
   "rewardsTitle": "Belohnungen",
   "rewardNoMistakesTitle": "Schließe die Herausforderung ohne Fehler ab",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "New game",
+  "continueGame": "Continue game",
   "weeklyProgress": "Weekly progress",
   "rewardsTitle": "Rewards",
   "rewardNoMistakesTitle": "Finish the challenge without mistakes",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "Nouvelle partie",
+  "continueGame": "Continuer la partie",
   "weeklyProgress": "Progression hebdomadaire",
   "rewardsTitle": "Récompenses",
   "rewardNoMistakesTitle": "Terminez le défi sans erreur",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "नया खेल",
+  "continueGame": "खेल जारी रखें",
   "weeklyProgress": "साप्ताहिक प्रगति",
   "rewardsTitle": "इनाम",
   "rewardNoMistakesTitle": "बिना गलती के चुनौती पूरी करें",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "Новая игра",
+  "continueGame": "Продолжить игру",
   "weeklyProgress": "Недельный прогресс",
   "rewardsTitle": "Награды",
   "rewardNoMistakesTitle": "Пройдите вызов без ошибок",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "Нова гра",
+  "continueGame": "Продовжити гру",
   "weeklyProgress": "Тижневий прогрес",
   "rewardsTitle": "Нагороди",
   "rewardNoMistakesTitle": "Завершіть виклик без помилок",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -48,6 +48,7 @@
     }
   },
   "newGame": "新游戏",
+  "continueGame": "继续游戏",
   "weeklyProgress": "每周进度",
   "rewardsTitle": "奖励",
   "rewardNoMistakesTitle": "无错误完成挑战",


### PR DESCRIPTION
## Summary
- persist in-progress games and surface a hasUnfinishedGame flag
- add a localized "Continue game" action above the new game button on the home card
- simplify the home top bar by removing the unused profile and trophy icons

## Testing
- Not run (flutter tool is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ca96e851e883268400ec6945185cc8