### PR TITLE
Fix build errors from constant tween and deprecated l10n option

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -3,7 +3,6 @@ template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
 output-class: AppLocalizations
 output-dir: lib/flutter_gen/gen_l10n
-synthetic-package: false
 untranslated-messages-file: build/l10n_missing_translations.txt
 use-deferred-loading: false
 

--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -53,7 +53,7 @@ class _BoardState extends State<Board> with TickerProviderStateMixin {
         ),
         weight: 40,
       ),
-      const TweenSequenceItem(
+      TweenSequenceItem(
         tween: ConstantTween<double>(0.65),
         weight: 20,
       ),


### PR DESCRIPTION
## Summary
- adjust the defeat overlay animation so the ConstantTween no longer sits in a const context
- remove the deprecated `synthetic-package` flag from the localization configuration

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac8d527208326bcf6ddd0206bbb57