### PR TITLE
Implement always-hidden completed digits and note mode UI

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -221,7 +221,6 @@ class AppState extends ChangeNotifier {
   bool soundsEnabled = true;
   bool musicEnabled = true;
   bool vibrationEnabled = true;
-  bool hideCompletedNumbers = false;
   int? highlightedNumber;
   DigitStyle digitStyle = DigitStyle.medium;
 
@@ -289,9 +288,6 @@ class AppState extends ChangeNotifier {
     soundsEnabled = prefs.getBool('soundsEnabled') ?? soundsEnabled;
     musicEnabled = prefs.getBool('musicEnabled') ?? musicEnabled;
     vibrationEnabled = prefs.getBool('vibrationEnabled') ?? vibrationEnabled;
-    hideCompletedNumbers =
-        prefs.getBool('hideCompletedNumbers') ?? hideCompletedNumbers;
-
     final savedGame = prefs.getString('currentGame');
     if (savedGame != null) {
       try {
@@ -434,15 +430,6 @@ class AppState extends ChangeNotifier {
     vibrationEnabled = enabled;
     _persist((prefs) async {
       await prefs.setBool('vibrationEnabled', enabled);
-    });
-    notifyListeners();
-  }
-
-  void toggleHideCompletedNumbers(bool enabled) {
-    if (hideCompletedNumbers == enabled) return;
-    hideCompletedNumbers = enabled;
-    _persist((prefs) async {
-      await prefs.setBool('hideCompletedNumbers', enabled);
     });
     notifyListeners();
   }

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -107,12 +107,6 @@ class SettingsPage extends StatelessWidget {
           const Divider(height: 32),
 
           _sectionTitle(l10n.miscSectionTitle),
-          SwitchListTile(
-            title: Text(l10n.hideCompletedNumbersLabel),
-            value: app.hideCompletedNumbers,
-            onChanged: app.toggleHideCompletedNumbers,
-            secondary: const Icon(Icons.visibility_off_outlined),
-          ),
           ListTile(
             leading: const Icon(Icons.info_outline),
             title: Text(l10n.aboutApp),

--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -117,13 +117,11 @@ class _BoardCell extends StatelessWidget {
           color: backgroundColor,
           border: border,
         ),
-        child: Center(
-          child: _CellContent(
-            value: value,
-            notes: notes,
-            incorrect: incorrect,
-            digitStyle: digitStyle,
-          ),
+        child: _CellContent(
+          value: value,
+          notes: notes,
+          incorrect: incorrect,
+          digitStyle: digitStyle,
         ),
       ),
     );
@@ -146,12 +144,14 @@ class _CellContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (value != 0) {
-      return Text(
-        value.toString(),
-        style: TextStyle(
-          fontSize: digitStyle.fontSize,
-          fontWeight: digitStyle.fontWeight,
-          color: incorrect ? const Color(0xFFE74C3C) : Colors.black,
+      return Center(
+        child: Text(
+          value.toString(),
+          style: TextStyle(
+            fontSize: digitStyle.fontSize,
+            fontWeight: digitStyle.fontWeight,
+            color: incorrect ? const Color(0xFFE74C3C) : Colors.black,
+          ),
         ),
       );
     }
@@ -175,27 +175,26 @@ class _NotesGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(4),
-      child: Wrap(
-        alignment: WrapAlignment.center,
-        spacing: 4,
-        runSpacing: 2,
-        children: [
-          for (var i = 1; i <= 9; i++)
-            SizedBox(
-              width: 14,
-              child: Text(
-                notes.contains(i) ? i.toString() : '',
-                textAlign: TextAlign.center,
+    final sorted = notes.toList()..sort();
+    return Align(
+      alignment: Alignment.topLeft,
+      child: Padding(
+        padding: const EdgeInsets.all(6),
+        child: Wrap(
+          spacing: 4,
+          runSpacing: 2,
+          children: [
+            for (final note in sorted)
+              Text(
+                note.toString(),
                 style: const TextStyle(
                   fontSize: 10,
                   color: Color(0xFF96A0C4),
                   fontWeight: FontWeight.w600,
                 ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -215,7 +215,7 @@ class _NumberPad extends StatelessWidget {
     final theme = Theme.of(context);
     final highlighted = app.highlightedNumber;
     final reduceMotion = MediaQuery.of(context).disableAnimations;
-    final hideCompleted = app.hideCompletedNumbers;
+    final notesMode = app.notesMode;
 
     return Container(
       decoration: BoxDecoration(
@@ -239,13 +239,13 @@ class _NumberPad extends StatelessWidget {
                 remaining: app.countRemaining(i + 1),
                 selected: selected == i + 1,
                 highlighted: highlighted == i + 1,
-                enabled:
-                    !hideCompleted || !app.isNumberCompleted(i + 1),
+                enabled: !app.isNumberCompleted(i + 1),
                 onTap: () => app.handleNumberInput(i + 1),
                 onHighlightStart: () => app.setHighlightedNumber(i + 1),
                 onHighlightEnd: () => app.setHighlightedNumber(null),
                 theme: theme,
                 reduceMotion: reduceMotion,
+                notesMode: notesMode,
               ),
             ),
         ],
@@ -265,6 +265,7 @@ class _NumberButton extends StatelessWidget {
   final VoidCallback onHighlightEnd;
   final ThemeData theme;
   final bool reduceMotion;
+  final bool notesMode;
 
   const _NumberButton({
     required this.number,
@@ -277,6 +278,7 @@ class _NumberButton extends StatelessWidget {
     required this.onHighlightEnd,
     required this.theme,
     required this.reduceMotion,
+    required this.notesMode,
   });
 
   @override
@@ -297,12 +299,15 @@ class _NumberButton extends StatelessWidget {
             : isHighlighted
                 ? const Color(0xFF9DBAFD)
                 : const Color(0xFFE2E5F3);
-    final textColor = enabled
-        ? const Color(0xFF1F2437)
-        : theme.disabledColor;
+    final textColor = !enabled
+        ? theme.disabledColor
+        : notesMode && !isSelected && !isHighlighted
+            ? const Color(0xFF6B7280)
+            : const Color(0xFF1F2437);
     final duration = reduceMotion
         ? Duration.zero
         : const Duration(milliseconds: 160);
+    final numberFontSize = notesMode ? 18.0 : 20.0;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4),
@@ -343,7 +348,7 @@ class _NumberButton extends StatelessWidget {
                 Text(
                   number.toString(),
                   style: TextStyle(
-                    fontSize: 20,
+                    fontSize: numberFontSize,
                     fontWeight: FontWeight.w700,
                     color: textColor,
                   ),


### PR DESCRIPTION
## Summary
- remove the hide completed digits toggle so the feature is always enabled
- update the number pad to gray out completed digits and highlight note mode visually
- render cell notes in the top-left corner for a notes-style experience

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0d35add08326b2ccbf79f0d6c857