### PR TITLE
Fix layout overflow and improve board visibility

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -112,8 +112,7 @@ class _GamePageState extends State<GamePage> {
             ),
             Expanded(
               child: SingleChildScrollView(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 32),
                 child: const Column(
                   children: [
                     Board(),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -28,6 +28,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
     return Scaffold(
       body: SafeArea(
+        minimum: const EdgeInsets.only(bottom: 16),
         child: IndexedStack(
           index: _index,
           children: pages,
@@ -133,6 +134,7 @@ class _HomeTab extends StatelessWidget {
     final difficulty = await showModalBottomSheet<Difficulty>(
       context: context,
       backgroundColor: Colors.white,
+      isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
       ),
@@ -141,46 +143,50 @@ class _HomeTab extends StatelessWidget {
         final selected = app.featuredStatsDifficulty;
         final sheetL10n = AppLocalizations.of(context)!;
 
-        return Padding(
-          padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Container(
-                width: 40,
-                height: 4,
-                decoration: BoxDecoration(
-                  color: const Color(0xFFD7DBEB),
-                  borderRadius: BorderRadius.circular(4),
+        return SafeArea(
+          top: false,
+          bottom: true,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFD7DBEB),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
                 ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                sheetL10n.selectDifficultyTitle,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w700,
+                const SizedBox(height: 16),
+                Text(
+                  sheetL10n.selectDifficultyTitle,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                ...List.generate(items.length, (index) {
+                  final diff = items[index];
+                  final stats = app.statsFor(diff);
+                  return Padding(
+                    padding: EdgeInsets.only(
+                      bottom: index < items.length - 1 ? 12.0 : 0.0,
                     ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-              ...List.generate(items.length, (index) {
-                final diff = items[index];
-                final stats = app.statsFor(diff);
-                return Padding(
-                  padding: EdgeInsets.only(
-                    bottom: index < items.length - 1 ? 12.0 : 0.0,
-                  ),
-                  child: _DifficultyTile(
-                    title: diff.title(sheetL10n),
-                    rankLabel: sheetL10n.rankLabel(stats.rank),
-                    progress: stats.progressText,
-                    isActive: diff == selected,
-                    onTap: () => Navigator.pop(context, diff),
-                  ),
-                );
-              }),
-            ],
+                    child: _DifficultyTile(
+                      title: diff.title(sheetL10n),
+                      rankLabel: sheetL10n.rankLabel(stats.rank),
+                      progress: stats.progressText,
+                      isActive: diff == selected,
+                      onTap: () => Navigator.pop(context, diff),
+                    ),
+                  );
+                }),
+              ],
+            ),
           ),
         );
       },

--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -204,7 +204,7 @@ Border _cellBorder(int index) {
   const thinLineColor = Color(0xFFD3D3D3);
   const boldLineColor = Color(0xFF555555);
   const thinLineWidth = 0.5;
-  const boldLineWidth = 1.2;
+  const boldLineWidth = 1.6;
 
   final row = index ~/ 9;
   final col = index % 9;


### PR DESCRIPTION
## Summary
- ensure the home screen content keeps clear of system insets by adding SafeArea padding and updating the difficulty picker bottom sheet
- give the game controls extra bottom padding so they no longer collide with the Android navigation bar
- slightly thicken the bold Sudoku grid lines for improved visibility

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1786b1e0832693ced2e48d305fab