### PR TITLE
Adjust home carousel padding for full-width scroll

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -87,14 +87,17 @@ class _HomeTab extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
 
     return SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+      padding: const EdgeInsets.symmetric(vertical: 24),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _TopBar(
-            onSettingsTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => const SettingsPage()),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: _TopBar(
+              onSettingsTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
+              ),
             ),
           ),
           const SizedBox(height: 24),
@@ -103,25 +106,35 @@ class _HomeTab extends StatelessWidget {
             championshipScore: app.championshipScore,
           ),
           const SizedBox(height: 32),
-          Text(
-            l10n.appTitle,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w700,
-              letterSpacing: -0.5,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.appTitle,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.5,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _DailyChain(streak: app.dailyStreak),
+                const SizedBox(height: 18),
+                _ProgressCard(
+                  stats: stats,
+                  onNewGame: () => _openDifficultySheet(context),
+                  onContinue: app.hasUnfinishedGame
+                      ? () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const GamePage(),
+                            ),
+                          )
+                      : null,
+                ),
+              ],
             ),
-          ),
-          const SizedBox(height: 12),
-          _DailyChain(streak: app.dailyStreak),
-          const SizedBox(height: 18),
-          _ProgressCard(
-            stats: stats,
-            onNewGame: () => _openDifficultySheet(context),
-            onContinue: app.hasUnfinishedGame
-                ? () => Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => const GamePage()),
-                    )
-                : null,
           ),
         ],
       ),
@@ -300,14 +313,18 @@ class _ChallengeCarousel extends StatelessWidget {
       ),
     ];
 
+    final screenWidth = MediaQuery.of(context).size.width;
+
     return SizedBox(
       height: 170,
-      child: ListView.separated(
+      child: ListView.builder(
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.only(right: 24),
-        itemBuilder: (context, index) => _ChallengeCard(data: cards[index]),
-        separatorBuilder: (_, __) => const SizedBox(width: 16),
+        padding: EdgeInsets.zero,
         itemCount: cards.length,
+        itemBuilder: (context, index) => SizedBox(
+          width: screenWidth,
+          child: _ChallengeCard(data: cards[index]),
+        ),
       ),
     );
   }
@@ -341,7 +358,7 @@ class _ChallengeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 240,
+      width: double.infinity,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(28),
         gradient: LinearGradient(


### PR DESCRIPTION
## Summary
- remove the outer horizontal padding from the home tab scroll view and reapply it only to the vertical sections that need gutters
- update the challenge carousel to use zero padding and ensure each card spans the full screen width while keeping the list flush with the viewport edges
- make the challenge card itself stretch to the available width to avoid premature clipping on either side

## Testing
- Not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cb1af3ee548326be1acc9abdce9244