### PR TITLE
Adjust challenge carousel spacing and card styling

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -314,15 +314,18 @@ class _ChallengeCarousel extends StatelessWidget {
     ];
 
     final screenWidth = MediaQuery.of(context).size.width;
+    final cardWidth = screenWidth - 48;
 
     return SizedBox(
       height: 170,
-      child: ListView.builder(
+      child: ListView.separated(
         scrollDirection: Axis.horizontal,
-        padding: EdgeInsets.zero,
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        clipBehavior: Clip.none,
         itemCount: cards.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 16),
         itemBuilder: (context, index) => SizedBox(
-          width: screenWidth,
+          width: cardWidth,
           child: _ChallengeCard(data: cards[index]),
         ),
       ),
@@ -366,6 +369,13 @@ class _ChallengeCard extends StatelessWidget {
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x1A1B1D3A),
+            blurRadius: 18,
+            offset: Offset(0, 10),
+          ),
+        ],
       ),
       padding: const EdgeInsets.all(20),
       child: Column(


### PR DESCRIPTION
## Summary
- restore horizontal padding and spacing in the challenge carousel so each card stays distinct while still scrolling cleanly to the screen edge
- add a subtle drop shadow to challenge cards to emphasize their standalone appearance

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1edec7188326b2a313877f768aef