### PR TITLE
fix: preload app state before building UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,10 +13,13 @@ Future<void> main() async {
   const locales = ['en', 'ru', 'uk', 'de', 'fr', 'zh', 'hi'];
   await Future.wait(locales.map(initializeDateFormatting));
 
+  final appState = AppState();
+  await appState.load();
+
   runApp(
     MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => AppState()..load()),
+        ChangeNotifierProvider.value(value: appState),
         ChangeNotifierProvider(create: (_) => UndoAdController()),
       ],
       child: const SudokuApp(),


### PR DESCRIPTION
## Summary
- create and load the global AppState before calling runApp to prevent re-entrant rebuilds
- provide the preloaded AppState instance to the widget tree so it no longer triggers the viewport assertion during mounting

## Testing
- not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cb221490048326a5e30566ea040713