### PR TITLE
Reduce size of challenge carousel cards

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -313,11 +313,14 @@ class _ChallengeCarousel extends StatelessWidget {
       ),
     ];
 
+    const scale = 0.7;
     final screenWidth = MediaQuery.of(context).size.width;
-    final cardWidth = screenWidth - 48;
+    final originalCardWidth = screenWidth - 48;
+    final cardWidth = originalCardWidth * scale;
+    final carouselHeight = 170 * scale;
 
     return SizedBox(
-      height: 170,
+      height: carouselHeight,
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: 24),
@@ -326,7 +329,15 @@ class _ChallengeCarousel extends StatelessWidget {
         separatorBuilder: (_, __) => const SizedBox(width: 16),
         itemBuilder: (context, index) => SizedBox(
           width: cardWidth,
-          child: _ChallengeCard(data: cards[index]),
+          height: carouselHeight,
+          child: FittedBox(
+            alignment: Alignment.centerLeft,
+            child: SizedBox(
+              width: originalCardWidth,
+              height: 170,
+              child: _ChallengeCard(data: cards[index]),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- scale the challenge carousel cards down to 70% of their original size with a fitted box wrapper
- shrink the carousel height to keep the more compact cards within the horizontal list while preserving spacing and styling

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb263c08bc832686c0290302aa06f3