### PR TITLE
Fix challenge carousel rendering error

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -321,23 +321,28 @@ class _ChallengeCarousel extends StatelessWidget {
 
     return SizedBox(
       height: carouselHeight,
-      child: ListView.separated(
+      child: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.symmetric(horizontal: 24),
         clipBehavior: Clip.none,
-        itemCount: cards.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 16),
-        itemBuilder: (context, index) => SizedBox(
-          width: cardWidth,
-          height: carouselHeight,
-          child: FittedBox(
-            alignment: Alignment.centerLeft,
-            child: SizedBox(
-              width: originalCardWidth,
-              height: 170,
-              child: _ChallengeCard(data: cards[index]),
-            ),
-          ),
+        child: Row(
+          children: [
+            for (var index = 0; index < cards.length; index++) ...[
+              if (index != 0) const SizedBox(width: 16),
+              SizedBox(
+                width: cardWidth,
+                height: carouselHeight,
+                child: FittedBox(
+                  alignment: Alignment.centerLeft,
+                  child: SizedBox(
+                    width: originalCardWidth,
+                    height: 170,
+                    child: _ChallengeCard(data: cards[index]),
+                  ),
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- replace the daily challenge carousel list view with a horizontal scroll view to avoid the sliver builder assertion that was triggered during rebuilds

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb28c71eb8832686cdbdb199b32e7b