### PR TITLE
Refine theme usage for dark mode UI

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -167,7 +167,7 @@ class _GamePageState extends State<GamePage> {
             return Transform.scale(scale: value, child: child);
           },
           child: Dialog(
-            backgroundColor: Colors.white,
+            backgroundColor: Theme.of(context).colorScheme.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(28),
             ),
@@ -185,8 +185,11 @@ class _GamePageState extends State<GamePage> {
                         colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
                       ),
                     ),
-                    child:
-                        const Icon(Icons.emoji_events, color: Colors.white, size: 36),
+                    child: Icon(
+                      Icons.emoji_events,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      size: 36,
+                    ),
                   ),
                   const SizedBox(height: 18),
                   Text(
@@ -200,8 +203,11 @@ class _GamePageState extends State<GamePage> {
                   Text(
                     l10n.victoryMessage(_formatTime(elapsedMs)),
                     textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: Color(0xFF6D7392),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.7),
                       fontSize: 14,
                     ),
                   ),
@@ -232,8 +238,10 @@ class _GamePageState extends State<GamePage> {
                             _victoryShown = false;
                           },
                           style: ElevatedButton.styleFrom(
-                            backgroundColor: const Color(0xFF3B82F6),
-                            foregroundColor: Colors.white,
+                            backgroundColor:
+                                Theme.of(context).colorScheme.primary,
+                            foregroundColor:
+                                Theme.of(context).colorScheme.onPrimary,
                             padding: const EdgeInsets.symmetric(vertical: 14),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(16),
@@ -277,7 +285,7 @@ class _GamePageState extends State<GamePage> {
           },
           child: Dialog(
             insetPadding: const EdgeInsets.symmetric(horizontal: 36),
-            backgroundColor: Colors.white,
+            backgroundColor: Theme.of(context).colorScheme.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(32),
             ),
@@ -295,7 +303,11 @@ class _GamePageState extends State<GamePage> {
                         colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
                       ),
                     ),
-                    child: const Icon(Icons.favorite, color: Colors.white, size: 40),
+                    child: Icon(
+                      Icons.favorite,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                      size: 40,
+                    ),
                   ),
                   const SizedBox(height: 18),
                   Text(
@@ -309,8 +321,11 @@ class _GamePageState extends State<GamePage> {
                   Text(
                     l10n.outOfLivesDescription,
                     textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: Color(0xFF6D7392),
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withOpacity(0.7),
                     ),
                   ),
                   const SizedBox(height: 24),
@@ -319,8 +334,10 @@ class _GamePageState extends State<GamePage> {
                     child: ElevatedButton(
                       onPressed: () => Navigator.pop(context, true),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFFFF5D7A),
-                        foregroundColor: Colors.white,
+                        backgroundColor:
+                            Theme.of(context).colorScheme.error,
+                        foregroundColor:
+                            Theme.of(context).colorScheme.onError,
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(18),
@@ -502,9 +519,9 @@ class _StatusBar extends StatelessWidget {
             ),
             child: Row(
               children: [
-                const Icon(
+                Icon(
                   Icons.star_rounded,
-                  color: Color(0xFFFFB347),
+                  color: scheme.secondary,
                   size: 20,
                 ),
                 const SizedBox(width: 6),
@@ -534,7 +551,8 @@ class _HeartsIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final inactive = theme.colorScheme.outlineVariant;
+    final scheme = theme.colorScheme;
+    final inactive = scheme.outlineVariant;
     return Row(
       children: List.generate(3, (index) {
         final active = index < lives;
@@ -543,7 +561,7 @@ class _HeartsIndicator extends StatelessWidget {
           child: Icon(
             Icons.favorite,
             size: 24,
-            color: active ? const Color(0xFFE25562) : inactive,
+            color: active ? scheme.error : inactive,
           ),
         );
       }),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -7,6 +7,7 @@ import 'game_page.dart';
 import 'models.dart';
 import 'settings_page.dart';
 import 'stats_page.dart';
+import 'theme.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -137,7 +138,7 @@ class _HomeTab extends StatelessWidget {
     final app = context.read<AppState>();
     final difficulty = await showModalBottomSheet<Difficulty>(
       context: context,
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
@@ -146,6 +147,8 @@ class _HomeTab extends StatelessWidget {
         final items = Difficulty.values;
         final selected = app.featuredStatsDifficulty;
         final sheetL10n = AppLocalizations.of(context)!;
+        final theme = Theme.of(context);
+        final scheme = theme.colorScheme;
 
         return SafeArea(
           top: false,
@@ -160,14 +163,14 @@ class _HomeTab extends StatelessWidget {
                   width: 40,
                   height: 4,
                   decoration: BoxDecoration(
-                    color: const Color(0xFFD7DBEB),
+                    color: scheme.outlineVariant,
                     borderRadius: BorderRadius.circular(4),
                   ),
                 ),
                 const SizedBox(height: 16),
                 Text(
                   sheetL10n.selectDifficultyTitle,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  style: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w700,
                   ),
                   textAlign: TextAlign.center,
@@ -232,6 +235,8 @@ class _CircleButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.extension<SudokuColors>()!;
     return InkResponse(
       onTap: onTap,
       radius: 28,
@@ -239,17 +244,17 @@ class _CircleButton extends StatelessWidget {
         width: 48,
         height: 48,
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: colors.headerButtonBackground,
           borderRadius: BorderRadius.circular(24),
-          boxShadow: const [
+          boxShadow: [
             BoxShadow(
-              color: Color(0x1A1B1D3A),
+              color: theme.shadowColor,
               blurRadius: 12,
-              offset: Offset(0, 6),
+              offset: const Offset(0, 6),
             ),
           ],
         ),
-        child: Icon(icon, color: const Color(0xFF3B82F6)),
+        child: Icon(icon, color: colors.headerButtonIcon),
       ),
     );
   }
@@ -351,6 +356,9 @@ class _ChallengeCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final onPrimary = scheme.onPrimary;
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
@@ -360,11 +368,11 @@ class _ChallengeCard extends StatelessWidget {
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
-        boxShadow: const [
+        boxShadow: [
           BoxShadow(
-            color: Color(0x1A1B1D3A),
+            color: theme.shadowColor,
             blurRadius: 18,
-            offset: Offset(0, 10),
+            offset: const Offset(0, 10),
           ),
         ],
       ),
@@ -377,8 +385,8 @@ class _ChallengeCard extends StatelessWidget {
             children: [
               Container(
                 padding: const EdgeInsets.all(10),
-                decoration: const BoxDecoration(
-                  color: Colors.white,
+                decoration: BoxDecoration(
+                  color: onPrimary,
                   shape: BoxShape.circle,
                 ),
                 child: Icon(data.icon, color: data.gradient.last, size: 22),
@@ -391,52 +399,55 @@ class _ChallengeCard extends StatelessWidget {
                     vertical: 4,
                   ),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.18),
+                    color: onPrimary.withOpacity(0.18),
                     borderRadius: BorderRadius.circular(30),
                   ),
                   child: Text(
                     data.badge!,
-                    style: const TextStyle(
-                      color: Colors.white,
+                    style: TextStyle(
+                      color: onPrimary,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                 ),
             ],
+        ),
+        const Spacer(),
+        Text(
+          data.title,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: onPrimary,
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
           ),
-          const Spacer(),
-          Text(
-            data.title,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 18,
-              fontWeight: FontWeight.w700,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          data.subtitle,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: onPrimary.withOpacity(0.7),
+            fontSize: 14,
+          ),
+        ),
+        const SizedBox(height: 18),
+        SizedBox(
+          height: 40,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: onPrimary,
+              foregroundColor: data.gradient.last,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(18),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+            ),
+            onPressed: data.onPressed,
+            child: Text(
+              data.buttonLabel,
+              style: const TextStyle(fontWeight: FontWeight.w600),
             ),
           ),
-          const SizedBox(height: 4),
-          Text(
-            data.subtitle,
-            style: const TextStyle(color: Colors.white70, fontSize: 14),
-          ),
-          const SizedBox(height: 18),
-          SizedBox(
-            height: 40,
-            child: ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white,
-                foregroundColor: data.gradient.last,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 24),
-              ),
-              onPressed: data.onPressed,
-              child: Text(
-                data.buttonLabel,
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
-            ),
-          ),
+        ),
         ],
       ),
     );
@@ -451,41 +462,45 @@ class _DailyChain extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final accent = scheme.error;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: scheme.surface,
         borderRadius: BorderRadius.circular(20),
-        boxShadow: const [
+        boxShadow: [
           BoxShadow(
-            color: Color(0x141B1D3A),
+            color: theme.shadowColor,
             blurRadius: 16,
-            offset: Offset(0, 8),
+            offset: const Offset(0, 8),
           ),
         ],
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Icon(Icons.local_fire_department, color: Color(0xFFFF713B)),
+          Icon(Icons.local_fire_department, color: accent),
           const SizedBox(width: 8),
           Text(
             l10n.dailyStreak,
-            style: Theme.of(
-              context,
-            ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: scheme.onSurface,
+            ),
           ),
           const SizedBox(width: 12),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
             decoration: BoxDecoration(
-              color: const Color(0xFFFFE2D5),
+              color: Color.alphaBlend(accent.withOpacity(0.16), scheme.surface),
               borderRadius: BorderRadius.circular(16),
             ),
             child: Text(
               streak.toString(),
-              style: const TextStyle(
-                color: Color(0xFFFD6E44),
+              style: TextStyle(
+                color: accent,
                 fontWeight: FontWeight.w600,
               ),
             ),
@@ -510,19 +525,20 @@ class _ProgressCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
 
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: scheme.surface,
         borderRadius: BorderRadius.circular(28),
-        boxShadow: const [
+        boxShadow: [
           BoxShadow(
-            color: Color(0x141B1D3A),
+            color: theme.shadowColor,
             blurRadius: 24,
-            offset: Offset(0, 16),
+            offset: const Offset(0, 16),
           ),
         ],
       ),
@@ -532,7 +548,7 @@ class _ProgressCard extends StatelessWidget {
           Text(
             l10n.rankProgress,
             style: theme.textTheme.labelLarge?.copyWith(
-              color: const Color(0xFF8187A5),
+              color: scheme.onSurface.withOpacity(0.68),
             ),
           ),
           const SizedBox(height: 8),
@@ -543,9 +559,9 @@ class _ProgressCard extends StatelessWidget {
               value: stats.progressTarget == 0
                   ? 0
                   : stats.progressCurrent / stats.progressTarget,
-              backgroundColor: const Color(0xFFD8E6FF),
-              valueColor: const AlwaysStoppedAnimation<Color>(
-                Color(0xFF3B82F6),
+              backgroundColor: scheme.primary.withOpacity(0.12),
+              valueColor: AlwaysStoppedAnimation<Color>(
+                scheme.primary,
               ),
             ),
           ),
@@ -554,6 +570,7 @@ class _ProgressCard extends StatelessWidget {
             l10n.rankLabel(stats.rank),
             style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
+              color: scheme.onSurface,
             ),
           ),
           const SizedBox(height: 24),
@@ -563,8 +580,8 @@ class _ProgressCard extends StatelessWidget {
               child: OutlinedButton(
                 onPressed: onContinue,
                 style: OutlinedButton.styleFrom(
-                  foregroundColor: const Color(0xFF3B82F6),
-                  side: const BorderSide(color: Color(0xFF3B82F6)),
+                  foregroundColor: scheme.primary,
+                  side: BorderSide(color: scheme.primary),
                   padding: const EdgeInsets.symmetric(vertical: 18),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(18),
@@ -586,8 +603,8 @@ class _ProgressCard extends StatelessWidget {
             child: ElevatedButton(
               onPressed: onNewGame,
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF3B82F6),
-                foregroundColor: Colors.white,
+                backgroundColor: scheme.primary,
+                foregroundColor: scheme.onPrimary,
                 padding: const EdgeInsets.symmetric(vertical: 18),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(18),
@@ -625,10 +642,15 @@ class _DifficultyTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final background = isActive ? const Color(0xFFFFEEF0) : Colors.white;
-    final borderColor = isActive
-        ? const Color(0xFFE86C82)
-        : const Color(0xFFE2E5F3);
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final background = isActive
+        ? Color.alphaBlend(scheme.primary.withOpacity(0.12), scheme.surface)
+        : scheme.surface;
+    final borderColor =
+        isActive ? scheme.primary : scheme.outlineVariant;
+    final titleColor = isActive ? scheme.primary : scheme.onSurface;
+    final mutedColor = scheme.onSurface.withOpacity(0.68);
 
     return InkWell(
       borderRadius: BorderRadius.circular(22),
@@ -648,18 +670,16 @@ class _DifficultyTile extends StatelessWidget {
                 children: [
                   Text(
                     title,
-                    style: TextStyle(
+                    style: theme.textTheme.bodyLarge?.copyWith(
                       fontWeight: FontWeight.w600,
-                      color: isActive
-                          ? const Color(0xFFE25562)
-                          : const Color(0xFF1F2437),
+                      color: titleColor,
                     ),
                   ),
                   const SizedBox(height: 4),
                   Text(
                     rankLabel,
-                    style: const TextStyle(
-                      color: Color(0xFF7A81A0),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: mutedColor,
                       fontSize: 12,
                     ),
                   ),
@@ -668,8 +688,8 @@ class _DifficultyTile extends StatelessWidget {
             ),
             Text(
               progress,
-              style: const TextStyle(
-                color: Color(0xFF7A81A0),
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: mutedColor,
                 fontWeight: FontWeight.w600,
               ),
             ),
@@ -766,6 +786,9 @@ class _DailyHeroCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final onPrimary = scheme.onPrimary;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
@@ -783,19 +806,21 @@ class _DailyHeroCard extends StatelessWidget {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.2),
+              color: onPrimary.withOpacity(0.2),
               borderRadius: BorderRadius.circular(16),
             ),
             child: Text(
               dateLabel,
-              style: const TextStyle(color: Colors.white70),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: onPrimary.withOpacity(0.7),
+              ),
             ),
           ),
           const SizedBox(height: 18),
           Text(
             l10n.todayPuzzle,
-            style: const TextStyle(
-              color: Colors.white,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: onPrimary,
               fontSize: 22,
               fontWeight: FontWeight.w700,
             ),
@@ -803,7 +828,10 @@ class _DailyHeroCard extends StatelessWidget {
           const SizedBox(height: 8),
           Text(
             l10n.todayPuzzleDescription,
-            style: const TextStyle(color: Colors.white70, fontSize: 14),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: onPrimary.withOpacity(0.7),
+              fontSize: 14,
+            ),
           ),
           const SizedBox(height: 20),
           SizedBox(
@@ -811,8 +839,8 @@ class _DailyHeroCard extends StatelessWidget {
             child: ElevatedButton(
               onPressed: () {},
               style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white,
-                foregroundColor: const Color(0xFF3B82F6),
+                backgroundColor: onPrimary,
+                foregroundColor: scheme.primary,
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
@@ -845,18 +873,24 @@ class _DayProgress extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final color = isToday
-        ? const Color(0xFF3B82F6)
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final baseColor = isToday
+        ? scheme.primary
         : completed
-        ? const Color(0xFF6ACB8A)
-        : const Color(0xFFB0B7D3);
+            ? scheme.secondary
+            : scheme.outlineVariant;
+    final background =
+        Color.alphaBlend(baseColor.withOpacity(0.15), scheme.surface);
+    final textColor =
+        isToday || completed ? baseColor : scheme.onSurface.withOpacity(0.7);
 
     return Column(
       children: [
         Text(
           label.toUpperCase(),
-          style: const TextStyle(
-            color: Color(0xFF7B83A6),
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: scheme.onSurface.withOpacity(0.6),
             fontSize: 11,
             fontWeight: FontWeight.w600,
           ),
@@ -866,14 +900,14 @@ class _DayProgress extends StatelessWidget {
           width: 52,
           height: 52,
           decoration: BoxDecoration(
-            color: color.withOpacity(0.15),
+            color: background,
             borderRadius: BorderRadius.circular(18),
           ),
           alignment: Alignment.center,
           child: Text(
             day.toString(),
-            style: TextStyle(
-              color: color,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: textColor,
               fontSize: 16,
               fontWeight: FontWeight.w700,
             ),
@@ -897,16 +931,18 @@ class _RewardTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: scheme.surface,
         borderRadius: BorderRadius.circular(20),
-        boxShadow: const [
+        boxShadow: [
           BoxShadow(
-            color: Color(0x0F1B1D3A),
+            color: theme.shadowColor,
             blurRadius: 18,
-            offset: Offset(0, 10),
+            offset: const Offset(0, 10),
           ),
         ],
       ),
@@ -916,25 +952,25 @@ class _RewardTile extends StatelessWidget {
             width: 42,
             height: 42,
             decoration: BoxDecoration(
-              color: const Color(0xFFD8E6FF),
+              color: scheme.primary.withOpacity(0.12),
               borderRadius: BorderRadius.circular(16),
             ),
-            child: Icon(icon, color: const Color(0xFF3B82F6)),
+            child: Icon(icon, color: scheme.primary),
           ),
           const SizedBox(width: 16),
           Expanded(
             child: Text(
               title,
-              style: const TextStyle(
+              style: theme.textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w600,
-                color: Color(0xFF1F2437),
+                color: scheme.onSurface,
               ),
             ),
           ),
           Text(
             reward,
-            style: const TextStyle(
-              color: Color(0xFF3B82F6),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: scheme.primary,
               fontWeight: FontWeight.w700,
             ),
           ),

--- a/lib/stats_page.dart
+++ b/lib/stats_page.dart
@@ -25,7 +25,14 @@ class _StatsTabState extends State<StatsTab> {
     final app = context.watch<AppState>();
     final stats = app.statsFor(_selected);
     final theme = Theme.of(context);
-    final primary = theme.colorScheme.primary;
+    final scheme = theme.colorScheme;
+    final primary = scheme.primary;
+    Color blend(Color a, Color b, double t) => Color.lerp(a, b, t) ?? a;
+    final winsAccent = scheme.secondary;
+    final rateAccent = blend(scheme.error, scheme.secondary, 0.5);
+    final flawlessAccent = blend(scheme.primary, scheme.onSurface, 0.3);
+    final averageTimeAccent = blend(scheme.primary, scheme.onSurface, 0.4);
+    final currentStreakAccent = blend(scheme.error, scheme.secondary, 0.35);
     final l10n = AppLocalizations.of(context)!;
 
     return SingleChildScrollView(
@@ -56,19 +63,19 @@ class _StatsTabState extends State<StatsTab> {
               ),
               _StatRowData(
                 icon: Icons.emoji_events_outlined,
-                color: const Color(0xFF6ACB8A),
+                color: winsAccent,
                 label: l10n.statsGamesWon,
                 value: stats.gamesWon.toString(),
               ),
               _StatRowData(
                 icon: Icons.pie_chart_outline,
-                color: const Color(0xFFE8736D),
+                color: rateAccent,
                 label: l10n.statsWinRate,
                 value: stats.winRateText,
               ),
               _StatRowData(
                 icon: Icons.shield_moon_outlined,
-                color: const Color(0xFFFFB347),
+                color: flawlessAccent,
                 label: l10n.statsFlawless,
                 value: stats.flawlessWins.toString(),
               ),
@@ -86,7 +93,7 @@ class _StatsTabState extends State<StatsTab> {
               ),
               _StatRowData(
                 icon: Icons.hourglass_bottom,
-                color: const Color(0xFF6D7392),
+                color: averageTimeAccent,
                 label: l10n.statsAverageTime,
                 value: stats.averageTimeText,
               ),
@@ -98,13 +105,13 @@ class _StatsTabState extends State<StatsTab> {
             rows: [
               _StatRowData(
                 icon: Icons.bolt_outlined,
-                color: const Color(0xFFFB923C),
+                color: currentStreakAccent,
                 label: l10n.statsCurrentStreak,
                 value: stats.currentStreak.toString(),
               ),
               _StatRowData(
                 icon: Icons.auto_graph_outlined,
-                color: primary,
+                color: winsAccent,
                 label: l10n.statsBestStreak,
                 value: stats.bestStreak.toString(),
               ),
@@ -128,7 +135,7 @@ class _DifficultySelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final primary = theme.colorScheme.primary;
+    final scheme = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
     return Wrap(
       spacing: 8,
@@ -139,12 +146,16 @@ class _DifficultySelector extends StatelessWidget {
             label: Text(diff.title(l10n)),
             selected: diff == selected,
             onSelected: (_) => onChanged(diff),
-            selectedColor: primary,
-            labelStyle: TextStyle(
-              color: diff == selected ? Colors.white : const Color(0xFF4C5472),
+            selectedColor: scheme.primary,
+            checkmarkColor: scheme.onPrimary,
+            labelStyle: theme.textTheme.labelLarge?.copyWith(
+              color: diff == selected ? scheme.onPrimary : scheme.onSurface,
               fontWeight: FontWeight.w600,
             ),
-            backgroundColor: const Color(0xFFE0ECFF),
+            backgroundColor: scheme.surfaceVariant,
+            side: BorderSide(
+              color: diff == selected ? scheme.primary : scheme.outlineVariant,
+            ),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(18),
             ),
@@ -163,18 +174,19 @@ class _StatsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
 
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: scheme.surface,
         borderRadius: BorderRadius.circular(28),
-        boxShadow: const [
+        boxShadow: [
           BoxShadow(
-            color: Color(0x121B1D3A),
+            color: theme.shadowColor,
             blurRadius: 18,
-            offset: Offset(0, 12),
+            offset: const Offset(0, 12),
           ),
         ],
       ),
@@ -185,6 +197,7 @@ class _StatsSection extends StatelessWidget {
             title,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w700,
+              color: scheme.onSurface,
             ),
           ),
           const SizedBox(height: 16),
@@ -195,7 +208,7 @@ class _StatsSection extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 child: Divider(
                   height: 1,
-                  color: theme.dividerColor?.withOpacity(0.4),
+                  color: scheme.outlineVariant,
                 ),
               ),
           ],
@@ -226,6 +239,8 @@ class _StatRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     return Row(
       children: [
         Container(
@@ -241,17 +256,17 @@ class _StatRow extends StatelessWidget {
         Expanded(
           child: Text(
             data.label,
-            style: const TextStyle(
+            style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
-              color: Color(0xFF1F2437),
+              color: scheme.onSurface,
             ),
           ),
         ),
         Text(
           data.value,
-          style: TextStyle(
+          style: theme.textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.w700,
-            color: Theme.of(context).colorScheme.primary,
+            color: scheme.primary,
           ),
         ),
       ],

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -195,6 +195,10 @@ class _ThemeConfig {
   final Color primary;
   final Color onPrimary;
   final Color onSurface;
+  final Color secondary;
+  final Color onSecondary;
+  final Color error;
+  final Color onError;
   final Color outline;
   final Color outlineVariant;
   final SudokuColors colors;
@@ -206,6 +210,10 @@ class _ThemeConfig {
     required this.primary,
     required this.onPrimary,
     required this.onSurface,
+    required this.secondary,
+    required this.onSecondary,
+    required this.error,
+    required this.onError,
     required this.outline,
     required this.outlineVariant,
     required this.colors,
@@ -216,24 +224,28 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
   SudokuTheme.white: _ThemeConfig(
     brightness: Brightness.light,
     background: const Color(0xFFF7FAFF),
-    surface: Colors.white,
+    surface: const Color(0xFFFFFFFF),
     primary: const Color(0xFF2563EB),
-    onPrimary: Colors.white,
+    onPrimary: const Color(0xFFFFFFFF),
     onSurface: const Color(0xFF172036),
+    secondary: const Color(0xFF6ACB8A),
+    onSecondary: const Color(0xFFFFFFFF),
+    error: const Color(0xFFE74C3C),
+    onError: const Color(0xFFFFFFFF),
     outline: const Color(0xFFDDE5F6),
     outlineVariant: const Color(0xFFE8EDF9),
     colors: const SudokuColors(
-      boardInner: Colors.white,
+      boardInner: Color(0xFFFFFFFF),
       boardBorder: Color(0xFFC7D3F4),
       selectedCell: Color(0xFFD9E7FF),
       sameNumberCell: Color(0xFFF1F5FF),
       noteColor: Color(0xFF7C8CB2),
-      headerButtonBackground: Colors.white,
+      headerButtonBackground: Color(0xFFFFFFFF),
       headerButtonIcon: Color(0xFF2563EB),
       actionButtonActiveBackground: Color(0xFFE1ECFF),
       actionButtonActiveBorder: Color(0xFF90B5FF),
       actionButtonBadgeColor: Color(0xFF1D4ED8),
-      numberPadBackground: Colors.white,
+      numberPadBackground: Color(0xFFFFFFFF),
       numberPadBorder: Color(0xFFE2E8F7),
       numberPadSelectedBackground: Color(0xFFC6DAFF),
       numberPadSelectedBorder: Color(0xFF1D4ED8),
@@ -251,8 +263,12 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
     background: const Color(0xFFF8F0DE),
     surface: const Color(0xFFFFF7E8),
     primary: const Color(0xFF3E8B6D),
-    onPrimary: Colors.white,
+    onPrimary: const Color(0xFFFFFFFF),
     onSurface: const Color(0xFF5A4529),
+    secondary: const Color(0xFF8AB89A),
+    onSecondary: const Color(0xFFFFFFFF),
+    error: const Color(0xFFE74C3C),
+    onError: const Color(0xFFFFFFFF),
     outline: const Color(0xFFE8DCC3),
     outlineVariant: const Color(0xFFF2E7CF),
     colors: const SudokuColors(
@@ -284,8 +300,12 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
     background: const Color(0xFFE6F7F1),
     surface: const Color(0xFFF3FBF7),
     primary: const Color(0xFF2F8D6A),
-    onPrimary: Colors.white,
+    onPrimary: const Color(0xFFFFFFFF),
     onSurface: const Color(0xFF153D2A),
+    secondary: const Color(0xFF78B894),
+    onSecondary: const Color(0xFFFFFFFF),
+    error: const Color(0xFFE74C3C),
+    onError: const Color(0xFFFFFFFF),
     outline: const Color(0xFFCFE7DF),
     outlineVariant: const Color(0xFFE2F1EC),
     colors: const SudokuColors(
@@ -317,8 +337,12 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
     background: const Color(0xFF121212),
     surface: const Color(0xFF1E1E1E),
     primary: const Color(0xFF3D82FF),
-    onPrimary: Colors.white,
+    onPrimary: const Color(0xFFFFFFFF),
     onSurface: const Color(0xFFE0E0E0),
+    secondary: const Color(0xFFE86C82),
+    onSecondary: const Color(0xFFFFFFFF),
+    error: const Color(0xFFFF5D7A),
+    onError: const Color(0xFFFFFFFF),
     outline: const Color(0xFF2A2A2A),
     outlineVariant: const Color(0xFF242424),
     colors: const SudokuColors(
@@ -355,8 +379,8 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
   ).copyWith(
     primary: config.primary,
     onPrimary: config.onPrimary,
-    secondary: config.primary,
-    onSecondary: config.onPrimary,
+    secondary: config.secondary,
+    onSecondary: config.onSecondary,
     tertiary: config.primary,
     onTertiary: config.onPrimary,
     background: config.background,
@@ -370,8 +394,8 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
     onSurfaceVariant: config.onSurface.withOpacity(0.72),
     outline: config.outline,
     outlineVariant: config.outlineVariant,
-    error: const Color(0xFFE74C3C),
-    onError: Colors.white,
+    error: config.error,
+    onError: config.onError,
     surfaceTint: Colors.transparent,
   );
 

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -32,6 +32,7 @@ class _ActionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final undoAds = context.watch<UndoAdController>();
     final canUndoMove = app.canUndoMove;
@@ -84,9 +85,8 @@ class _ActionRow extends StatelessWidget {
             label: l10n.hint,
             onPressed: app.hintsLeft > 0 ? app.useHint : null,
             badge: app.hintsLeft.toString(),
-            badgeColor: app.hintsLeft > 0
-                ? const Color(0xFFFFB347)
-                : theme.disabledColor,
+            badgeColor:
+                app.hintsLeft > 0 ? scheme.secondary : theme.disabledColor,
           ),
         ),
       ],

--- a/lib/widgets/theme_menu.dart
+++ b/lib/widgets/theme_menu.dart
@@ -164,9 +164,9 @@ class _ThemeCircle extends StatelessWidget {
               ),
             ),
             if (active)
-              const Icon(
+              Icon(
                 Icons.check,
-                color: Colors.white,
+                color: scheme.onPrimary,
                 size: 22,
               ),
           ],


### PR DESCRIPTION
## Summary
- derive the stats tab accent colors from the active ColorScheme instead of hard-coded values
- update the game HUD icons and control panel hint badge to respect the current theme palette

## Testing
- flutter test *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc039eb7dc8326b3417518c5220ded