### PR TITLE
Centralize themed color usage

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -158,6 +158,8 @@ class _GamePageState extends State<GamePage> {
         final duration = reduceMotion
             ? Duration.zero
             : const Duration(milliseconds: 220);
+        final theme = Theme.of(context);
+        final colors = theme.extension<SudokuColors>()!;
 
         return TweenAnimationBuilder<double>(
           tween: Tween(begin: reduceMotion ? 1.0 : 0.85, end: 1.0),
@@ -167,7 +169,7 @@ class _GamePageState extends State<GamePage> {
             return Transform.scale(scale: value, child: child);
           },
           child: Dialog(
-            backgroundColor: Theme.of(context).colorScheme.surface,
+            backgroundColor: theme.colorScheme.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(28),
             ),
@@ -179,15 +181,13 @@ class _GamePageState extends State<GamePage> {
                   Container(
                     width: 72,
                     height: 72,
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      gradient: LinearGradient(
-                        colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
-                      ),
+                      gradient: colors.victoryBadgeGradient,
                     ),
                     child: Icon(
                       Icons.emoji_events,
-                      color: Theme.of(context).colorScheme.onPrimary,
+                      color: theme.colorScheme.onPrimary,
                       size: 36,
                     ),
                   ),
@@ -203,11 +203,8 @@ class _GamePageState extends State<GamePage> {
                   Text(
                     l10n.victoryMessage(_formatTime(elapsedMs)),
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withOpacity(0.7),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.7),
                       fontSize: 14,
                     ),
                   ),
@@ -271,6 +268,8 @@ class _GamePageState extends State<GamePage> {
         final duration = reduceMotion
             ? Duration.zero
             : const Duration(milliseconds: 220);
+        final theme = Theme.of(context);
+        final colors = theme.extension<SudokuColors>()!;
 
         return TweenAnimationBuilder<double>(
           tween: Tween(begin: reduceMotion ? 1.0 : 0.0, end: 1.0),
@@ -285,7 +284,7 @@ class _GamePageState extends State<GamePage> {
           },
           child: Dialog(
             insetPadding: const EdgeInsets.symmetric(horizontal: 36),
-            backgroundColor: Theme.of(context).colorScheme.surface,
+            backgroundColor: theme.colorScheme.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(32),
             ),
@@ -297,15 +296,13 @@ class _GamePageState extends State<GamePage> {
                   Container(
                     width: 88,
                     height: 88,
-                    decoration: const BoxDecoration(
+                    decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      gradient: LinearGradient(
-                        colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
-                      ),
+                      gradient: colors.failureBadgeGradient,
                     ),
                     child: Icon(
                       Icons.favorite,
-                      color: Theme.of(context).colorScheme.onPrimary,
+                      color: theme.colorScheme.onPrimary,
                       size: 40,
                     ),
                   ),
@@ -321,11 +318,8 @@ class _GamePageState extends State<GamePage> {
                   Text(
                     l10n.outOfLivesDescription,
                     textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withOpacity(0.7),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.7),
                     ),
                   ),
                   const SizedBox(height: 24),
@@ -334,10 +328,8 @@ class _GamePageState extends State<GamePage> {
                     child: ElevatedButton(
                       onPressed: () => Navigator.pop(context, true),
                       style: ElevatedButton.styleFrom(
-                        backgroundColor:
-                            Theme.of(context).colorScheme.error,
-                        foregroundColor:
-                            Theme.of(context).colorScheme.onError,
+                        backgroundColor: theme.colorScheme.error,
+                        foregroundColor: theme.colorScheme.onError,
                         padding: const EdgeInsets.symmetric(vertical: 16),
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(18),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -274,13 +274,14 @@ class _ChallengeCarousel extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final formatter = DateFormat('d MMMM', l10n.localeName);
     final today = formatter.format(DateTime.now());
+    final colors = Theme.of(context).extension<SudokuColors>()!;
 
     final cards = [
       _ChallengeCardData(
         title: l10n.navDaily,
         subtitle: today,
         buttonLabel: l10n.playAction,
-        gradient: const [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        gradient: colors.dailyChallengeGradient,
         icon: Icons.emoji_events,
         onPressed: () {},
       ),
@@ -288,7 +289,7 @@ class _ChallengeCarousel extends StatelessWidget {
         title: l10n.championshipTitle,
         subtitle: l10n.championshipScore(championshipScore),
         buttonLabel: l10n.playAction,
-        gradient: const [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        gradient: colors.championshipChallengeGradient,
         icon: Icons.workspace_premium_outlined,
         onPressed: () {},
         badge: '2G',
@@ -297,7 +298,7 @@ class _ChallengeCarousel extends StatelessWidget {
         title: l10n.battleTitle,
         subtitle: l10n.battleWinRate(battleWinRate),
         buttonLabel: l10n.startAction,
-        gradient: const [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        gradient: colors.battleChallengeGradient,
         icon: Icons.sports_esports_outlined,
         onPressed: () {},
       ),
@@ -333,7 +334,7 @@ class _ChallengeCardData {
   final String title;
   final String subtitle;
   final String buttonLabel;
-  final List<Color> gradient;
+  final LinearGradient gradient;
   final IconData icon;
   final VoidCallback onPressed;
   final String? badge;
@@ -363,11 +364,7 @@ class _ChallengeCard extends StatelessWidget {
       width: double.infinity,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(28),
-        gradient: LinearGradient(
-          colors: data.gradient,
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
+        gradient: data.gradient,
         boxShadow: [
           BoxShadow(
             color: theme.shadowColor,
@@ -389,7 +386,11 @@ class _ChallengeCard extends StatelessWidget {
                   color: onPrimary,
                   shape: BoxShape.circle,
                 ),
-                child: Icon(data.icon, color: data.gradient.last, size: 22),
+                child: Icon(
+                  data.icon,
+                  color: data.gradient.colors.last,
+                  size: 22,
+                ),
               ),
               const Spacer(),
               if (data.badge != null)
@@ -435,7 +436,7 @@ class _ChallengeCard extends StatelessWidget {
           child: ElevatedButton(
             style: ElevatedButton.styleFrom(
               backgroundColor: onPrimary,
-              foregroundColor: data.gradient.last,
+              foregroundColor: data.gradient.colors.last,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(18),
               ),
@@ -789,15 +790,12 @@ class _DailyHeroCard extends StatelessWidget {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final onPrimary = scheme.onPrimary;
+    final colors = theme.extension<SudokuColors>()!;
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [Color(0xFF9AD3FF), Color(0xFF4E8BFF)],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
+        gradient: colors.dailyHeroGradient,
         borderRadius: BorderRadius.circular(28),
       ),
       child: Column(

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -43,6 +43,12 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
   final Color numberPadRemaining;
   final Color numberPadRemainingHighlight;
   final Color shadowColor;
+  final LinearGradient dailyChallengeGradient;
+  final LinearGradient championshipChallengeGradient;
+  final LinearGradient battleChallengeGradient;
+  final LinearGradient dailyHeroGradient;
+  final LinearGradient victoryBadgeGradient;
+  final LinearGradient failureBadgeGradient;
 
   const SudokuColors({
     required this.boardInner,
@@ -66,6 +72,12 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
     required this.numberPadRemaining,
     required this.numberPadRemainingHighlight,
     required this.shadowColor,
+    required this.dailyChallengeGradient,
+    required this.championshipChallengeGradient,
+    required this.battleChallengeGradient,
+    required this.dailyHeroGradient,
+    required this.victoryBadgeGradient,
+    required this.failureBadgeGradient,
   });
 
   @override
@@ -91,6 +103,12 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
     Color? numberPadRemaining,
     Color? numberPadRemainingHighlight,
     Color? shadowColor,
+    LinearGradient? dailyChallengeGradient,
+    LinearGradient? championshipChallengeGradient,
+    LinearGradient? battleChallengeGradient,
+    LinearGradient? dailyHeroGradient,
+    LinearGradient? victoryBadgeGradient,
+    LinearGradient? failureBadgeGradient,
   }) {
     return SudokuColors(
       boardInner: boardInner ?? this.boardInner,
@@ -125,6 +143,17 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
       numberPadRemainingHighlight: numberPadRemainingHighlight ??
           this.numberPadRemainingHighlight,
       shadowColor: shadowColor ?? this.shadowColor,
+      dailyChallengeGradient:
+          dailyChallengeGradient ?? this.dailyChallengeGradient,
+      championshipChallengeGradient: championshipChallengeGradient ??
+          this.championshipChallengeGradient,
+      battleChallengeGradient:
+          battleChallengeGradient ?? this.battleChallengeGradient,
+      dailyHeroGradient: dailyHeroGradient ?? this.dailyHeroGradient,
+      victoryBadgeGradient:
+          victoryBadgeGradient ?? this.victoryBadgeGradient,
+      failureBadgeGradient:
+          failureBadgeGradient ?? this.failureBadgeGradient,
     );
   }
 
@@ -138,6 +167,13 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
     }
 
     Color _lerp(Color a, Color b) => Color.lerp(a, b, t) ?? b;
+    LinearGradient _lerpGradient(LinearGradient a, LinearGradient b) {
+      final result = Gradient.lerp(a, b, t);
+      if (result is LinearGradient) {
+        return result;
+      }
+      return b;
+    }
 
     return SudokuColors(
       boardInner: _lerp(boardInner, other.boardInner),
@@ -184,6 +220,19 @@ class SudokuColors extends ThemeExtension<SudokuColors> {
         other.numberPadRemainingHighlight,
       ),
       shadowColor: _lerp(shadowColor, other.shadowColor),
+      dailyChallengeGradient:
+          _lerpGradient(dailyChallengeGradient, other.dailyChallengeGradient),
+      championshipChallengeGradient: _lerpGradient(
+        championshipChallengeGradient,
+        other.championshipChallengeGradient,
+      ),
+      battleChallengeGradient:
+          _lerpGradient(battleChallengeGradient, other.battleChallengeGradient),
+      dailyHeroGradient: _lerpGradient(dailyHeroGradient, other.dailyHeroGradient),
+      victoryBadgeGradient:
+          _lerpGradient(victoryBadgeGradient, other.victoryBadgeGradient),
+      failureBadgeGradient:
+          _lerpGradient(failureBadgeGradient, other.failureBadgeGradient),
     );
   }
 }
@@ -256,6 +305,32 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
       numberPadRemaining: Color(0xFF8893AD),
       numberPadRemainingHighlight: Color(0xFF1D4ED8),
       shadowColor: Color(0x141B1D3A),
+      dailyChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      championshipChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      battleChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      dailyHeroGradient: const LinearGradient(
+        colors: [Color(0xFF9AD3FF), Color(0xFF4E8BFF)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      victoryBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
+      ),
+      failureBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
+      ),
     ),
   ),
   SudokuTheme.cream: _ThemeConfig(
@@ -293,6 +368,32 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
       numberPadRemaining: Color(0xFFB39663),
       numberPadRemainingHighlight: Color(0xFF2F7457),
       shadowColor: Color(0x1A7B5E2F),
+      dailyChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      championshipChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      battleChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      dailyHeroGradient: const LinearGradient(
+        colors: [Color(0xFF9AD3FF), Color(0xFF4E8BFF)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      victoryBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
+      ),
+      failureBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
+      ),
     ),
   ),
   SudokuTheme.green: _ThemeConfig(
@@ -330,6 +431,32 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
       numberPadRemaining: Color(0xFF779C86),
       numberPadRemainingHighlight: Color(0xFF1F7252),
       shadowColor: Color(0x14304933),
+      dailyChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      championshipChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      battleChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      dailyHeroGradient: const LinearGradient(
+        colors: [Color(0xFF9AD3FF), Color(0xFF4E8BFF)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      victoryBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
+      ),
+      failureBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
+      ),
     ),
   ),
   SudokuTheme.black: _ThemeConfig(
@@ -367,6 +494,32 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
       numberPadRemaining: Color(0xFF808894),
       numberPadRemainingHighlight: Color(0xFF3D82FF),
       shadowColor: Color(0x66000000),
+      dailyChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      championshipChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      battleChallengeGradient: const LinearGradient(
+        colors: [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      dailyHeroGradient: const LinearGradient(
+        colors: [Color(0xFF9AD3FF), Color(0xFF4E8BFF)],
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+      ),
+      victoryBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFFC26F), Color(0xFFFF8A5B)],
+      ),
+      failureBadgeGradient: const LinearGradient(
+        colors: [Color(0xFFFF8095), Color(0xFFFF4D6D)],
+      ),
     ),
   ),
 };


### PR DESCRIPTION
## Summary
- add gradient support to `SudokuColors` and define gradient palettes for every theme
- update the home and game screens to consume gradients and colors exclusively from the theme

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc0be6091483269e23b2800902a234