### PR TITLE
Adjust theme menu layout and font slider options

### DIFF
--- a/lib/widgets/theme_menu.dart
+++ b/lib/widgets/theme_menu.dart
@@ -44,24 +44,16 @@ class _ThemeDialog extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 16),
-                SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  padding: EdgeInsets.zero,
-                  child: Row(
-                    children: [
-                      for (var i = 0; i < themeOptions.length; i++)
-                        Padding(
-                          padding: EdgeInsets.only(
-                            right: i == themeOptions.length - 1 ? 0 : 12,
-                          ),
-                          child: _ThemeCircle(
-                            option: themeOptions[i],
-                            active: themeOptions[i] == activeTheme,
-                            onTap: () => app.setTheme(themeOptions[i]),
-                          ),
-                        ),
-                    ],
-                  ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    for (final option in themeOptions)
+                      _ThemeCircle(
+                        option: option,
+                        active: option == activeTheme,
+                        onTap: () => app.setTheme(option),
+                      ),
+                  ],
                 ),
                 const SizedBox(height: 16),
                 Text(
@@ -87,6 +79,7 @@ class _ThemeDialog extends StatelessWidget {
                         value: app.fontSizeSp,
                         min: AppState.minFontSizeSp,
                         max: AppState.maxFontSizeSp,
+                        divisions: AppState.fontSizeOptionsSp.length - 1,
                         onChanged: (value) =>
                             app.setFontSizeSp(value, save: false),
                         onChangeEnd: app.setFontSizeSp,


### PR DESCRIPTION
## Summary
- distribute the theme selection buttons evenly across a single row in the settings dialog
- limit the font size slider to three discrete values and normalize stored font scale values to match

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc0fe2bd40832694463c0b9e64eaf8