### PR TITLE
Set dark theme preview color to black

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -628,5 +628,8 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
 
 /// Цвет, который используется для предпросмотра темы в меню выбора.
 Color themePreviewColor(SudokuTheme theme) {
+  if (theme == SudokuTheme.black) {
+    return const Color(0xFF000000);
+  }
   return _themeConfigs[theme]!.primary;
 }


### PR DESCRIPTION
## Summary
- update `themePreviewColor` so the dark theme preview uses solid black instead of the theme primary color

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3a60fcdc8326a68fe9386b4a3aaa