### PR TITLE
Add stats page scaffold

### DIFF
--- a/lib/stats_page.dart
+++ b/lib/stats_page.dart
@@ -4,6 +4,25 @@ import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'models.dart';
 
+class StatsPage extends StatelessWidget {
+  const StatsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.statsTitle),
+        centerTitle: true,
+      ),
+      body: const SafeArea(
+        bottom: false,
+        child: StatsTab(),
+      ),
+    );
+  }
+}
+
 class StatsTab extends StatefulWidget {
   const StatsTab({super.key});
 


### PR DESCRIPTION
## Summary
- add a StatsPage widget with its own scaffold and app bar
- reuse the existing StatsTab within the new page so navigation from the home screen works

## Testing
- not run (flutter is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68cc41a6da4483269e5111286de2ca47