### PR TITLE
Debounce game state saves

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -44,6 +44,7 @@ class _GamePageState extends State<GamePage> {
   @override
   void dispose() {
     _timer?.cancel();
+    context.read<AppState>().save();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- add a debounce timer for saving the current game state and reuse it across gameplay mutations
- keep the original save logic and expose a manual save method for flushing pending writes
- ensure the game page flushes any pending save when the widget is disposed

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7a404e0483268bd3cce8d371018d