### PR TITLE
Fix missing ValueListenable import

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';


### PR DESCRIPTION
## Summary
- import flutter foundation to make ValueListenable available in the game page

## Testing
- `flutter analyze` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc809c7dd08326abe033b02ca5c246