### PR TITLE
Keep home, daily, and stats tabs alive

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -70,11 +70,20 @@ class _BottomNavBar extends StatelessWidget {
   }
 }
 
-class _HomeTab extends StatelessWidget {
+class _HomeTab extends StatefulWidget {
   const _HomeTab();
 
   @override
+  State<_HomeTab> createState() => _HomeTabState();
+}
+
+class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
     final app = context.watch<AppState>();
     final theme = Theme.of(context);
     final difficulty = app.featuredStatsDifficulty;
@@ -740,7 +749,9 @@ class _DailyChallengesTab extends StatefulWidget {
 }
 
 class _DailyChallengesTabState extends State<_DailyChallengesTab>
-    with SingleTickerProviderStateMixin {
+    with
+        SingleTickerProviderStateMixin<_DailyChallengesTab>,
+        AutomaticKeepAliveClientMixin<_DailyChallengesTab> {
   late DateTime _visibleMonth;
   late int _preferredDay;
   DateTime? _selectedDate;
@@ -891,7 +902,11 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
   }
 
   @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
     final app = context.watch<AppState>();
     final sudokuTheme = app.resolvedTheme();
     final l10n = AppLocalizations.of(context)!;

--- a/lib/stats_page.dart
+++ b/lib/stats_page.dart
@@ -30,7 +30,8 @@ class StatsTab extends StatefulWidget {
   State<StatsTab> createState() => _StatsTabState();
 }
 
-class _StatsTabState extends State<StatsTab> {
+class _StatsTabState extends State<StatsTab>
+    with AutomaticKeepAliveClientMixin<StatsTab> {
   late Difficulty _selected;
 
   @override
@@ -40,7 +41,11 @@ class _StatsTabState extends State<StatsTab> {
   }
 
   @override
+  bool get wantKeepAlive => true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
     final app = context.watch<AppState>();
     final stats = app.statsFor(_selected);
     final theme = Theme.of(context);


### PR DESCRIPTION
## Summary
- convert the home tab to a stateful keep-alive widget so its UI state persists
- keep the daily challenges tab alive while preserving its existing animation controller
- ensure the stats tab keeps its state when switching between bottom navigation items

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc847ed98c83269f8b09dbfe3bf005