### PR TITLE
Optimize widgets with consts, theme caching, and undo dialog guard

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -166,11 +166,11 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
         borderRadius: BorderRadius.vertical(top: Radius.circular(32)),
       ),
       builder: (context) {
+        final theme = Theme.of(context);
+        final cs = theme.colorScheme;
         final items = Difficulty.values;
         final selected = app.featuredStatsDifficulty;
         final sheetL10n = AppLocalizations.of(context)!;
-        final theme = Theme.of(context);
-        final scheme = theme.colorScheme;
 
         return SafeArea(
           top: false,
@@ -185,8 +185,8 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
                   width: 40,
                   height: 4,
                   decoration: BoxDecoration(
-                    color: scheme.outlineVariant,
-                    borderRadius: BorderRadius.circular(4),
+                    color: cs.outlineVariant,
+                    borderRadius: const BorderRadius.all(Radius.circular(4)),
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -206,6 +206,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
                       bottom: index < items.length - 1 ? 12.0 : 0.0,
                     ),
                     child: _DifficultyTile(
+                      key: ValueKey(_difficultyKey(diff)),
                       title: diff.title(sheetL10n),
                       rankLabel: sheetL10n.rankLabel(stats.rank),
                       progress: stats.progressText,
@@ -228,6 +229,21 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
       context,
       MaterialPageRoute(builder: (_) => const GamePage()),
     );
+  }
+}
+
+String _difficultyKey(Difficulty difficulty) {
+  switch (difficulty) {
+    case Difficulty.novice:
+      return 'home-diff-beginner';
+    case Difficulty.medium:
+      return 'home-diff-intermediate';
+    case Difficulty.high:
+      return 'home-diff-advanced';
+    case Difficulty.expert:
+      return 'home-diff-expert';
+    case Difficulty.master:
+      return 'home-diff-master';
   }
 }
 
@@ -284,7 +300,7 @@ class _CircleButton extends StatelessWidget {
         height: 48,
         decoration: BoxDecoration(
           color: colors.headerButtonBackground,
-          borderRadius: BorderRadius.circular(24),
+          borderRadius: const BorderRadius.all(Radius.circular(24)),
           boxShadow: [
             BoxShadow(
               color: theme.shadowColor,
@@ -310,10 +326,11 @@ class _ChallengeCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context)!;
     final formatter = DateFormat('d MMMM', l10n.localeName);
     final today = formatter.format(DateTime.now());
-    final colors = Theme.of(context).extension<SudokuColors>()!;
+    final colors = theme.extension<SudokuColors>()!;
 
     final cards = [
       _ChallengeCardData(
@@ -397,12 +414,12 @@ class _ChallengeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final onPrimary = scheme.onPrimary;
+    final cs = theme.colorScheme;
+    final onPrimary = cs.onPrimary;
     return Container(
       width: double.infinity,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(28),
+        borderRadius: const BorderRadius.all(Radius.circular(28)),
         gradient: data.gradient,
         boxShadow: [
           BoxShadow(
@@ -440,7 +457,7 @@ class _ChallengeCard extends StatelessWidget {
                   ),
                   decoration: BoxDecoration(
                     color: onPrimary.withOpacity(0.18),
-                    borderRadius: BorderRadius.circular(30),
+                    borderRadius: const BorderRadius.all(Radius.circular(30)),
                   ),
                   child: Text(
                     data.badge!,
@@ -476,8 +493,8 @@ class _ChallengeCard extends StatelessWidget {
             style: ElevatedButton.styleFrom(
               backgroundColor: onPrimary,
               foregroundColor: data.gradient.colors.last,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(18),
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(18)),
               ),
               padding: const EdgeInsets.symmetric(horizontal: 24),
             ),
@@ -501,15 +518,15 @@ class _DailyChain extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final accent = scheme.error;
+    final cs = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+    final accent = cs.error;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
       decoration: BoxDecoration(
-        color: scheme.surface,
-        borderRadius: BorderRadius.circular(20),
+        color: cs.surface,
+        borderRadius: const BorderRadius.all(Radius.circular(20)),
         boxShadow: [
           BoxShadow(
             color: theme.shadowColor,
@@ -527,15 +544,15 @@ class _DailyChain extends StatelessWidget {
             l10n.dailyStreak,
             style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
-              color: scheme.onSurface,
+              color: cs.onSurface,
             ),
           ),
           const SizedBox(width: 12),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
             decoration: BoxDecoration(
-              color: Color.alphaBlend(accent.withOpacity(0.16), scheme.surface),
-              borderRadius: BorderRadius.circular(16),
+              color: Color.alphaBlend(accent.withOpacity(0.16), cs.surface),
+              borderRadius: const BorderRadius.all(Radius.circular(16)),
             ),
             child: Text(
               streak.toString(),
@@ -565,15 +582,15 @@ class _ProgressCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
 
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: scheme.surface,
-        borderRadius: BorderRadius.circular(28),
+        color: cs.surface,
+        borderRadius: const BorderRadius.all(Radius.circular(28)),
         boxShadow: [
           BoxShadow(
             color: theme.shadowColor,
@@ -588,20 +605,20 @@ class _ProgressCard extends StatelessWidget {
           Text(
             l10n.rankProgress,
             style: theme.textTheme.labelLarge?.copyWith(
-              color: scheme.onSurface.withOpacity(0.68),
+              color: cs.onSurface.withOpacity(0.68),
             ),
           ),
           const SizedBox(height: 8),
           ClipRRect(
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: const BorderRadius.all(Radius.circular(12)),
             child: LinearProgressIndicator(
               minHeight: 10,
               value: stats.progressTarget == 0
                   ? 0
                   : stats.progressCurrent / stats.progressTarget,
-              backgroundColor: scheme.primary.withOpacity(0.12),
+              backgroundColor: cs.primary.withOpacity(0.12),
               valueColor: AlwaysStoppedAnimation<Color>(
-                scheme.primary,
+                cs.primary,
               ),
             ),
           ),
@@ -610,7 +627,7 @@ class _ProgressCard extends StatelessWidget {
             l10n.rankLabel(stats.rank),
             style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
-              color: scheme.onSurface,
+              color: cs.onSurface,
             ),
           ),
           const SizedBox(height: 24),
@@ -618,13 +635,14 @@ class _ProgressCard extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: OutlinedButton(
+                key: const ValueKey('home-continue'),
                 onPressed: onContinue,
                 style: OutlinedButton.styleFrom(
-                  foregroundColor: scheme.primary,
-                  side: BorderSide(color: scheme.primary),
+                  foregroundColor: cs.primary,
+                  side: BorderSide(color: cs.primary),
                   padding: const EdgeInsets.symmetric(vertical: 18),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(18),
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(18)),
                   ),
                 ),
                 child: Text(
@@ -643,11 +661,11 @@ class _ProgressCard extends StatelessWidget {
             child: ElevatedButton(
               onPressed: onNewGame,
               style: ElevatedButton.styleFrom(
-                backgroundColor: scheme.primary,
-                foregroundColor: scheme.onPrimary,
+                backgroundColor: cs.primary,
+                foregroundColor: cs.onPrimary,
                 padding: const EdgeInsets.symmetric(vertical: 18),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(18),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(18)),
                 ),
               ),
               child: Text(
@@ -683,23 +701,22 @@ class _DifficultyTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final background = isActive
-        ? Color.alphaBlend(scheme.primary.withOpacity(0.12), scheme.surface)
-        : scheme.surface;
-    final borderColor =
-        isActive ? scheme.primary : scheme.outlineVariant;
-    final titleColor = isActive ? scheme.primary : scheme.onSurface;
-    final mutedColor = scheme.onSurface.withOpacity(0.68);
+        ? Color.alphaBlend(cs.primary.withOpacity(0.12), cs.surface)
+        : cs.surface;
+    final borderColor = isActive ? cs.primary : cs.outlineVariant;
+    final titleColor = isActive ? cs.primary : cs.onSurface;
+    final mutedColor = cs.onSurface.withOpacity(0.68);
 
     return InkWell(
-      borderRadius: BorderRadius.circular(22),
+      borderRadius: const BorderRadius.all(Radius.circular(22)),
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
         decoration: BoxDecoration(
           color: background,
-          borderRadius: BorderRadius.circular(22),
+          borderRadius: const BorderRadius.all(Radius.circular(22)),
           border: Border.all(color: borderColor),
         ),
         child: Row(
@@ -909,9 +926,9 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
     super.build(context);
     final app = context.watch<AppState>();
     final sudokuTheme = app.resolvedTheme();
-    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     final today = DateTime.now();
     final normalizedToday = DateTime(today.year, today.month, today.day);
@@ -941,18 +958,18 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
     final canPlay =
         currentSelected != null && !currentSelected.isAfter(normalizedToday);
 
-    final surfaceColor = scheme.surface;
+    final surfaceColor = cs.surface;
     final headerGradient = LinearGradient(
       colors: [
-        scheme.primary,
-        Color.lerp(scheme.primary, scheme.onPrimary, 0.25) ?? scheme.primary,
+        cs.primary,
+        Color.lerp(cs.primary, cs.onPrimary, 0.25) ?? cs.primary,
       ],
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
     );
 
     return Container(
-      color: scheme.background,
+      color: cs.background,
       child: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -975,18 +992,18 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                     opacity: _trophyOpacity,
                     child: ScaleTransition(
                       scale: _trophyScale,
-                      child: Container(
-                        width: 110,
-                        height: 110,
-                        decoration: BoxDecoration(
-                          color: scheme.onPrimary.withOpacity(0.12),
-                          shape: BoxShape.circle,
-                        ),
-                        child: Icon(
-                          Icons.emoji_events_rounded,
-                          color: scheme.onPrimary,
-                          size: 60,
-                        ),
+                        child: Container(
+                          width: 110,
+                          height: 110,
+                          decoration: BoxDecoration(
+                            color: cs.onPrimary.withOpacity(0.12),
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            Icons.emoji_events_rounded,
+                            color: cs.onPrimary,
+                            size: 60,
+                          ),
                       ),
                     ),
                   ),
@@ -1003,7 +1020,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                             l10n.navDaily,
                             textAlign: TextAlign.center,
                             style: theme.textTheme.headlineMedium?.copyWith(
-                              color: scheme.onPrimary,
+                              color: cs.onPrimary,
                               fontWeight: FontWeight.w800,
                               letterSpacing: -0.4,
                             ),
@@ -1022,7 +1039,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                               Text(
                                 '$headerProgress/$challengeGoal',
                                 style: theme.textTheme.titleMedium?.copyWith(
-                                  color: scheme.onPrimary,
+                                  color: cs.onPrimary,
                                   fontWeight: FontWeight.w700,
                                 ),
                               ),
@@ -1047,7 +1064,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                       padding: const EdgeInsets.fromLTRB(20, 28, 20, 28),
                       decoration: BoxDecoration(
                         color: surfaceColor,
-                        borderRadius: BorderRadius.circular(28),
+                        borderRadius: const BorderRadius.all(Radius.circular(28)),
                         boxShadow: [
                           BoxShadow(
                             color: theme.shadowColor,
@@ -1072,7 +1089,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                                   textAlign: TextAlign.center,
                                   style: theme.textTheme.titleMedium?.copyWith(
                                     fontWeight: FontWeight.w700,
-                                    color: scheme.onSurface,
+                                    color: cs.onSurface,
                                   ),
                                 ),
                               ),
@@ -1094,7 +1111,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                                     label.toUpperCase(),
                                     style: theme.textTheme.labelSmall?.copyWith(
                                       fontWeight: FontWeight.w600,
-                                      color: scheme.onSurface,
+                                      color: cs.onSurface,
                                     ),
                                   ),
                                 ),
@@ -1147,19 +1164,19 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                                   ? () => _startDaily(app, currentSelected)
                                   : null,
                               style: ElevatedButton.styleFrom(
-                                backgroundColor: scheme.primary,
-                                foregroundColor: scheme.onPrimary,
+                                backgroundColor: cs.primary,
+                                foregroundColor: cs.onPrimary,
                                 padding:
                                     const EdgeInsets.symmetric(vertical: 18, horizontal: 16),
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(22),
+                                shape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.all(Radius.circular(22)),
                                 ),
                                 elevation: 0,
                               ),
                               child: Text(
                                 l10n.playAction,
                                 style: theme.textTheme.titleMedium?.copyWith(
-                                  color: scheme.onPrimary,
+                                  color: cs.onPrimary,
                                   fontWeight: FontWeight.w800,
                                   letterSpacing: 0.1,
                                 ),
@@ -1226,16 +1243,16 @@ class _CalendarDayButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final textColor = _resolveTextColor(scheme);
+    final cs = theme.colorScheme;
+    final textColor = _resolveTextColor(cs);
     final textStyle = (theme.textTheme.titleSmall ?? const TextStyle()).copyWith(
       fontWeight: FontWeight.w700,
       color: textColor,
     );
-    final indicatorColor = selected ? scheme.onPrimary : scheme.secondary;
+    final indicatorColor = selected ? cs.onPrimary : cs.secondary;
     final border = today
         ? Border.all(
-            color: selected ? scheme.onPrimary : scheme.primary,
+            color: selected ? cs.onPrimary : cs.primary,
             width: 3,
           )
         : null;
@@ -1248,7 +1265,7 @@ class _CalendarDayButton extends StatelessWidget {
         duration: const Duration(milliseconds: 200),
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: selected ? scheme.primary : Colors.transparent,
+          color: selected ? cs.primary : Colors.transparent,
           border: border,
         ),
         padding: const EdgeInsets.all(4),

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -36,6 +36,7 @@ class SettingsPage extends StatelessWidget {
           _sectionTitle(l10n.languageSectionTitle),
           ...AppLanguage.values.map(
                 (lang) => RadioListTile<AppLanguage>(
+              key: ValueKey('lang-${lang.name}'),
               title: Text(lang.displayName(l10n)),
               value: lang,
               groupValue: app.lang,

--- a/lib/stats_page.dart
+++ b/lib/stats_page.dart
@@ -49,14 +49,14 @@ class _StatsTabState extends State<StatsTab>
     final app = context.watch<AppState>();
     final stats = app.statsFor(_selected);
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    final primary = scheme.primary;
+    final cs = theme.colorScheme;
+    final primary = cs.primary;
     Color blend(Color a, Color b, double t) => Color.lerp(a, b, t) ?? a;
-    final winsAccent = scheme.secondary;
-    final rateAccent = blend(scheme.error, scheme.secondary, 0.5);
-    final flawlessAccent = blend(scheme.primary, scheme.onSurface, 0.3);
-    final averageTimeAccent = blend(scheme.primary, scheme.onSurface, 0.4);
-    final currentStreakAccent = blend(scheme.error, scheme.secondary, 0.35);
+    final winsAccent = cs.secondary;
+    final rateAccent = blend(cs.error, cs.secondary, 0.5);
+    final flawlessAccent = blend(cs.primary, cs.onSurface, 0.3);
+    final averageTimeAccent = blend(cs.primary, cs.onSurface, 0.4);
+    final currentStreakAccent = blend(cs.error, cs.secondary, 0.35);
     final l10n = AppLocalizations.of(context)!;
 
     return SingleChildScrollView(
@@ -159,7 +159,7 @@ class _DifficultySelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
     return Wrap(
       spacing: 8,
@@ -170,18 +170,18 @@ class _DifficultySelector extends StatelessWidget {
             label: Text(diff.title(l10n)),
             selected: diff == selected,
             onSelected: (_) => onChanged(diff),
-            selectedColor: scheme.primary,
-            checkmarkColor: scheme.onPrimary,
+            selectedColor: cs.primary,
+            checkmarkColor: cs.onPrimary,
             labelStyle: theme.textTheme.labelLarge?.copyWith(
-              color: diff == selected ? scheme.onPrimary : scheme.onSurface,
+              color: diff == selected ? cs.onPrimary : cs.onSurface,
               fontWeight: FontWeight.w600,
             ),
-            backgroundColor: scheme.surfaceVariant,
+            backgroundColor: cs.surfaceVariant,
             side: BorderSide(
-              color: diff == selected ? scheme.primary : scheme.outlineVariant,
+              color: diff == selected ? cs.primary : cs.outlineVariant,
             ),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(18),
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(18)),
             ),
           ),
       ],
@@ -198,14 +198,14 @@ class _StatsSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
 
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: scheme.surface,
-        borderRadius: BorderRadius.circular(28),
+        color: cs.surface,
+        borderRadius: const BorderRadius.all(Radius.circular(28)),
         boxShadow: [
           BoxShadow(
             color: theme.shadowColor,
@@ -221,7 +221,7 @@ class _StatsSection extends StatelessWidget {
             title,
             style: theme.textTheme.titleMedium?.copyWith(
               fontWeight: FontWeight.w700,
-              color: scheme.onSurface,
+              color: cs.onSurface,
             ),
           ),
           const SizedBox(height: 16),
@@ -232,7 +232,7 @@ class _StatsSection extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 child: Divider(
                   height: 1,
-                  color: scheme.outlineVariant,
+                  color: cs.outlineVariant,
                 ),
               ),
           ],
@@ -264,7 +264,7 @@ class _StatRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     return Row(
       children: [
         Container(
@@ -272,7 +272,7 @@ class _StatRow extends StatelessWidget {
           height: 46,
           decoration: BoxDecoration(
             color: data.color.withOpacity(0.12),
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: const BorderRadius.all(Radius.circular(16)),
           ),
           child: Icon(data.icon, color: data.color),
         ),
@@ -282,7 +282,7 @@ class _StatRow extends StatelessWidget {
             data.label,
             style: theme.textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
-              color: scheme.onSurface,
+              color: cs.onSurface,
             ),
           ),
         ),
@@ -290,7 +290,7 @@ class _StatRow extends StatelessWidget {
           data.value,
           style: theme.textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.w700,
-            color: scheme.primary,
+            color: cs.primary,
           ),
         ),
       ],

--- a/lib/undo_ad_controller.dart
+++ b/lib/undo_ad_controller.dart
@@ -93,8 +93,12 @@ class _UndoAdDialogState extends State<_UndoAdDialog> {
     _secondsLeft = widget.duration.inSeconds;
     if (_secondsLeft <= 0) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) {
-          Navigator.of(context).pop();
+        if (!mounted) {
+          return;
+        }
+        final navigator = Navigator.of(context, rootNavigator: true);
+        if (navigator.canPop()) {
+          navigator.pop();
         }
       });
       return;
@@ -113,7 +117,13 @@ class _UndoAdDialogState extends State<_UndoAdDialog> {
 
       if (remaining <= 0) {
         timer.cancel();
-        Navigator.of(context).pop();
+        if (!mounted) {
+          return;
+        }
+        final navigator = Navigator.of(context, rootNavigator: true);
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
       }
     });
   }
@@ -127,7 +137,8 @@ class _UndoAdDialogState extends State<_UndoAdDialog> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final primary = theme.colorScheme.primary;
+    final cs = theme.colorScheme;
+    final primary = cs.primary;
 
     final total = widget.duration.inSeconds;
     final seconds = (_secondsLeft.clamp(0, total)).toInt();
@@ -135,7 +146,7 @@ class _UndoAdDialogState extends State<_UndoAdDialog> {
 
     return Dialog(
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: const BorderRadius.all(Radius.circular(24)),
       ),
       insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
       child: Padding(
@@ -165,7 +176,7 @@ class _UndoAdDialogState extends State<_UndoAdDialog> {
             ),
             const SizedBox(height: 24),
             ClipRRect(
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
               child: LinearProgressIndicator(
                 value: progress.clamp(0.0, 1.0),
                 minHeight: 10,

--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -10,8 +10,9 @@ class Board extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final colors = theme.extension<SudokuColors>()!;
-    final surfaceColor = theme.colorScheme.surface;
+    final surfaceColor = cs.surface;
 
     return Consumer<AppState>(
       builder: (context, app, _) {
@@ -25,7 +26,7 @@ class Board extends StatelessWidget {
           child: Container(
             decoration: BoxDecoration(
               color: surfaceColor,
-              borderRadius: BorderRadius.circular(28),
+              borderRadius: const BorderRadius.all(Radius.circular(28)),
               boxShadow: [
                 BoxShadow(
                   color: colors.shadowColor,
@@ -40,11 +41,11 @@ class Board extends StatelessWidget {
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: colors.boardInner,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
                   border: Border.all(color: colors.boardBorder, width: 4),
                 ),
                 child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
                   child: GridView.builder(
                     padding: EdgeInsets.zero,
                     physics: const NeverScrollableScrollPhysics(),
@@ -107,14 +108,15 @@ class _BoardCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final colors = theme.extension<SudokuColors>()!;
     final baseInner = colors.boardInner;
     final thinColor = Color.alphaBlend(
-      theme.colorScheme.onSurface.withOpacity(0.08),
+      cs.onSurface.withOpacity(0.08),
       baseInner,
     );
     final boldColor = Color.alphaBlend(
-      theme.colorScheme.onSurface.withOpacity(0.18),
+      cs.onSurface.withOpacity(0.18),
       baseInner,
     );
     final border = _cellBorder(index, thinColor, boldColor);
@@ -159,8 +161,9 @@ class _CellContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final colors = theme.extension<SudokuColors>()!;
-    final onSurface = theme.colorScheme.onSurface;
+    final onSurface = cs.onSurface;
     if (value != 0) {
       return Center(
         child: AnimatedDefaultTextStyle(
@@ -169,7 +172,7 @@ class _CellContent extends StatelessWidget {
           style: TextStyle(
             fontSize: 20 * fontScale,
             fontWeight: FontWeight.w600,
-            color: incorrect ? theme.colorScheme.error : onSurface,
+            color: incorrect ? cs.error : onSurface,
           ),
           child: Text(value.toString()),
         ),
@@ -198,7 +201,8 @@ class _NotesGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final sorted = notes.toList()..sort();
-    final colors = Theme.of(context).extension<SudokuColors>()!;
+    final theme = Theme.of(context);
+    final colors = theme.extension<SudokuColors>()!;
     return Align(
       alignment: Alignment.topLeft,
       child: Padding(

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -31,7 +31,7 @@ class _ActionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
     final undoAds = context.watch<UndoAdController>();
     final useUndoAd = undoAds.useAdFlow;
@@ -106,8 +106,7 @@ class _ActionRow extends StatelessWidget {
                 onPressed:
                     enabled ? context.read<AppState>().useHint : null,
                 badge: hintsLeft.toString(),
-                badgeColor:
-                    enabled ? scheme.secondary : theme.disabledColor,
+                badgeColor: enabled ? cs.secondary : theme.disabledColor,
               );
             },
           ),
@@ -138,31 +137,31 @@ class _ActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final colors = theme.extension<SudokuColors>()!;
-    final scheme = theme.colorScheme;
     final enabled = onPressed != null;
     final isActive = enabled && active;
     final background = isActive
         ? colors.actionButtonActiveBackground
-        : scheme.surface;
+        : cs.surface;
     final borderColor = isActive
         ? colors.actionButtonActiveBorder
-        : scheme.outlineVariant;
+        : cs.outlineVariant;
     final disabledBorder = Color.alphaBlend(
-      scheme.onSurface.withOpacity(0.05),
-      scheme.surface,
+      cs.onSurface.withOpacity(0.05),
+      cs.surface,
     );
     final effectiveBorder = enabled ? borderColor : disabledBorder;
-    final disabledColor = scheme.onSurface.withOpacity(0.35);
+    final disabledColor = cs.onSurface.withOpacity(0.35);
     final textColor = isActive
-        ? scheme.primary
+        ? cs.primary
         : enabled
-            ? scheme.onSurface
+            ? cs.onSurface
             : disabledColor;
     final iconColor = isActive
-        ? scheme.primary
+        ? cs.primary
         : enabled
-            ? scheme.onSurface
+            ? cs.onSurface
             : disabledColor;
     final baseBadge = badgeColor ?? colors.actionButtonBadgeColor;
     final badgeForeground = enabled ? baseBadge : baseBadge.withOpacity(0.4);
@@ -413,7 +412,7 @@ class _NumberButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final isSelected = enabled && selected;
     final isHighlighted = enabled && highlighted;
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final background = !enabled
         ? colors.numberPadDisabledBackground
         : isSelected
@@ -422,7 +421,10 @@ class _NumberButton extends StatelessWidget {
                 ? colors.numberPadHighlightBackground
                 : colors.numberPadBackground;
     final borderColor = !enabled
-        ? Color.alphaBlend(scheme.onSurface.withOpacity(0.05), colors.numberPadBackground)
+        ? Color.alphaBlend(
+            cs.onSurface.withOpacity(0.05),
+            colors.numberPadBackground,
+          )
         : isSelected
             ? colors.numberPadSelectedBorder
             : isHighlighted
@@ -431,8 +433,8 @@ class _NumberButton extends StatelessWidget {
     final textColor = !enabled
         ? colors.numberPadDisabledText
         : notesMode && !isSelected && !isHighlighted
-            ? scheme.onSurface.withOpacity(0.7)
-            : scheme.onSurface;
+            ? cs.onSurface.withOpacity(0.7)
+            : cs.onSurface;
     final duration = reduceMotion
         ? Duration.zero
         : const Duration(milliseconds: 160);

--- a/lib/widgets/theme_menu.dart
+++ b/lib/widgets/theme_menu.dart
@@ -17,8 +17,9 @@ class _ThemeDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
@@ -71,7 +72,7 @@ class _ThemeDialog extends StatelessWidget {
                       style: TextStyle(
                         fontSize: AppState.minFontSizeSp,
                         fontWeight: FontWeight.w600,
-                        color: theme.colorScheme.onSurface.withOpacity(0.7),
+                        color: cs.onSurface.withOpacity(0.7),
                       ),
                     ),
                     Expanded(
@@ -90,7 +91,7 @@ class _ThemeDialog extends StatelessWidget {
                       style: TextStyle(
                         fontSize: AppState.maxFontSizeSp,
                         fontWeight: FontWeight.w700,
-                        color: theme.colorScheme.onSurface,
+                        color: cs.onSurface,
                       ),
                     ),
                   ],
@@ -118,9 +119,9 @@ class _ThemeCircle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
+    final cs = theme.colorScheme;
     final baseColor = themePreviewColor(option);
-    final borderColor = active ? scheme.primary : scheme.outlineVariant;
+    final borderColor = active ? cs.primary : cs.outlineVariant;
 
     return GestureDetector(
       onTap: onTap,
@@ -150,7 +151,7 @@ class _ThemeCircle extends StatelessWidget {
             if (active)
               Icon(
                 Icons.check,
-                color: scheme.onPrimary,
+                color: cs.onPrimary,
                 size: 22,
               ),
           ],


### PR DESCRIPTION
## Summary
- cache Theme/ColorScheme/AppLocalizations lookups and add const decorations across the board, control panel, stats, settings, theme menu, and home screen widgets to reduce rebuild overhead
- add stable ValueKey identifiers for the home difficulty actions and language radio tiles so Flutter can better reuse elements
- guard the undo ad dialog against unmounted contexts before calling Navigator.pop

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8b52be0883269639885af45df544