### PR TITLE
Allow difficulty tiles to accept keys

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -691,6 +691,7 @@ class _DifficultyTile extends StatelessWidget {
   final VoidCallback onTap;
 
   const _DifficultyTile({
+    super.key,
     required this.title,
     required this.rankLabel,
     required this.progress,


### PR DESCRIPTION
## Summary
- allow `_DifficultyTile` to accept a `Key` so callers can pass one when building the sheet

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8eb9d1e08326afc9c80eb8146a31