### PR TITLE
Adjust challenge carousel card width

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -369,7 +369,19 @@ class _ChallengeCarousel extends StatelessWidget {
     const cardSpacing = 16.0;
     const cardHeight = 196.0;
     final availableWidth = screenWidth - horizontalPadding * 2;
-    final cardWidth = availableWidth.clamp(0.0, 360.0).toDouble();
+
+    final showTwoCards = screenWidth < 600;
+    final double cardWidth;
+    if (showTwoCards) {
+      final widthForTwoCards = availableWidth - cardSpacing;
+      if (widthForTwoCards > 0) {
+        cardWidth = widthForTwoCards / 2;
+      } else {
+        cardWidth = availableWidth > 0 ? availableWidth : 0;
+      }
+    } else {
+      cardWidth = availableWidth.clamp(0.0, 360.0).toDouble();
+    }
 
     return SizedBox(
       height: cardHeight,


### PR DESCRIPTION
## Summary
- adjust the challenge carousel card sizing to display two cards at once on phones
- retain the previous card width on larger layouts for consistency

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd20ab15b483268f0ce85721f70d31