### PR TITLE
Add Championship page UI and navigation

### DIFF
--- a/lib/championship/championship_page.dart
+++ b/lib/championship/championship_page.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../flutter_gen/gen_l10n/app_localizations.dart';
+import '../game_page.dart';
+import '../models.dart';
+import '../theme.dart';
+
+class ChampionshipPage extends StatelessWidget {
+  const ChampionshipPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final colors = theme.extension<SudokuColors>()!;
+    final l10n = AppLocalizations.of(context)!;
+
+    const difficulties = [
+      Difficulty.novice,
+      Difficulty.medium,
+      Difficulty.high,
+      Difficulty.expert,
+      Difficulty.master,
+    ];
+
+    final rounds = difficulties
+        .map(
+          (difficulty) => _ChampionshipRoundData(
+            difficulty: difficulty,
+            description: l10n.championshipRoundDescriptionPlaceholder,
+            badgeLabel: difficulty.shortLabel(l10n),
+          ),
+        )
+        .toList(growable: false);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.championshipTitle),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                decoration: BoxDecoration(
+                  gradient: colors.championshipChallengeGradient,
+                  borderRadius: const BorderRadius.all(Radius.circular(24)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: theme.shadowColor,
+                      blurRadius: 18,
+                      offset: const Offset(0, 10),
+                    ),
+                  ],
+                ),
+                child: Text(
+                  l10n.championshipScore(0),
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: cs.onPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: ListView.separated(
+                  itemBuilder: (context, index) {
+                    final round = rounds[index];
+                    return _ChampionshipRoundCard(
+                      key: ValueKey('round-$index'),
+                      data: round,
+                      onPlay: () => _startRound(context, round.difficulty),
+                    );
+                  },
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemCount: rounds.length,
+                  padding: EdgeInsets.zero,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _startRound(BuildContext context, Difficulty difficulty) {
+    final app = context.read<AppState>();
+    app.startGame(difficulty);
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const GamePage()),
+    );
+  }
+}
+
+class _ChampionshipRoundData {
+  final Difficulty difficulty;
+  final String description;
+  final String? badgeLabel;
+
+  const _ChampionshipRoundData({
+    required this.difficulty,
+    required this.description,
+    this.badgeLabel,
+  });
+}
+
+class _ChampionshipRoundCard extends StatelessWidget {
+  final _ChampionshipRoundData data;
+  final VoidCallback onPlay;
+
+  const _ChampionshipRoundCard({
+    super.key,
+    required this.data,
+    required this.onPlay,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: const BorderRadius.all(Radius.circular(24)),
+        boxShadow: [
+          BoxShadow(
+            color: theme.shadowColor,
+            blurRadius: 18,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  data.difficulty.title(l10n),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              if (data.badgeLabel != null)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: Color.alphaBlend(
+                      cs.primary.withOpacity(0.12),
+                      cs.surface,
+                    ),
+                    borderRadius: const BorderRadius.all(Radius.circular(16)),
+                  ),
+                  child: Text(
+                    data.badgeLabel!,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: cs.primary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            data.description,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 18),
+          SizedBox(
+            height: 40,
+            child: ElevatedButton(
+              onPressed: onPlay,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: cs.primary,
+                foregroundColor: cs.onPrimary,
+                padding: const EdgeInsets.symmetric(horizontal: 24),
+                shape: const RoundedRectangleBorder(
+                  borderRadius: BorderRadius.all(Radius.circular(18)),
+                ),
+              ),
+              child: Text(
+                l10n.playAction,
+                style: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -62,6 +62,8 @@ abstract class AppLocalizations {
 
   String championshipScore(int score);
 
+  String get championshipRoundDescriptionPlaceholder;
+
   String get battleTitle;
 
   String battleWinRate(int percent);
@@ -339,6 +341,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String championshipScore(int score) {
     return "Punktestand ${score}";
   }
+
+  @override
+  String get championshipRoundDescriptionPlaceholder => "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.";
 
   @override
   String get battleTitle => "Duell";
@@ -684,6 +689,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get championshipRoundDescriptionPlaceholder => "Play this round to boost your championship run.";
+
+  @override
   String get battleTitle => "Battle";
 
   @override
@@ -1025,6 +1033,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String championshipScore(int score) {
     return "Score ${score}";
   }
+
+  @override
+  String get championshipRoundDescriptionPlaceholder => "Jouez cette manche pour booster votre parcours au championnat.";
 
   @override
   String get battleTitle => "Duel";
@@ -1370,6 +1381,9 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String get championshipRoundDescriptionPlaceholder => "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।";
+
+  @override
   String get battleTitle => "बैटल";
 
   @override
@@ -1711,6 +1725,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String championshipScore(int score) {
     return "Счёт ${score}";
   }
+
+  @override
+  String get championshipRoundDescriptionPlaceholder => "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.";
 
   @override
   String get battleTitle => "Битва";
@@ -2060,6 +2077,9 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String get championshipRoundDescriptionPlaceholder => "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.";
+
+  @override
   String get battleTitle => "Битва";
 
   @override
@@ -2405,6 +2425,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String championshipScore(int score) {
     return "得分 ${score}";
   }
+
+  @override
+  String get championshipRoundDescriptionPlaceholder => "进行这一轮，推动你的锦标赛征程。";
 
   @override
   String get battleTitle => "对战";

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -377,7 +377,7 @@ class _ChallengeCarousel extends StatelessWidget {
         buttonLabel: l10n.playAction,
         gradient: colors.championshipChallengeGradient,
         icon: Icons.workspace_premium_outlined,
-        onPressed: () {},
+        onPressed: () => Navigator.pushNamed(context, '/championship'),
         badge: '2G',
       ),
       _ChallengeCardData(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.",
   "battleTitle": "Duell",
   "battleWinRate": "Siegquote {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "Play this round to boost your championship run.",
   "battleTitle": "Battle",
   "battleWinRate": "Win rate {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "Jouez cette manche pour booster votre parcours au championnat.",
   "battleTitle": "Duel",
   "battleWinRate": "Taux de victoire {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।",
   "battleTitle": "बैटल",
   "battleWinRate": "जीत दर {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.",
   "battleTitle": "Битва",
   "battleWinRate": "Процент побед {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.",
   "battleTitle": "Битва",
   "battleWinRate": "Відсоток перемог {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -17,6 +17,7 @@
       }
     }
   },
+  "championshipRoundDescriptionPlaceholder": "进行这一轮，推动你的锦标赛征程。",
   "battleTitle": "对战",
   "battleWinRate": "胜率 {percent}%",
   "@battleWinRate": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'championship/championship_page.dart';
 import 'home_screen.dart';
 import 'models.dart';
 import 'theme.dart';
@@ -61,6 +62,9 @@ class SudokuApp extends StatelessWidget {
           data: media.copyWith(textScaleFactor: app.fontScale),
           child: child ?? const SizedBox.shrink(),
         );
+      },
+      routes: {
+        '/championship': (context) => const ChampionshipPage(),
       },
       home: const HomeScreen(),
     );


### PR DESCRIPTION
## Summary
- register the Championship route and wire the home card to push it
- implement the new Championship page with score pill and round list UI
- add a localized placeholder description for championship rounds in all locales

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3bb2c6408326bbfe98656d2fa15f