### PR TITLE
Add championship progress model and persistence

### DIFF
--- a/lib/championship/championship_model.dart
+++ b/lib/championship/championship_model.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models.dart';
+
+enum ChampionshipRoundStatus { notStarted, inProgress, completed }
+
+class ChampionshipRound {
+  final Difficulty difficulty;
+  ChampionshipRoundStatus status;
+  DateTime? startedAt;
+  DateTime? finishedAt;
+
+  ChampionshipRound({
+    required this.difficulty,
+    this.status = ChampionshipRoundStatus.notStarted,
+    this.startedAt,
+    this.finishedAt,
+  });
+
+  Map<String, dynamic> toMap() => {
+        'difficulty': difficulty.name,
+        'status': status.name,
+        'startedAt': startedAt?.toUtc().toIso8601String(),
+        'finishedAt': finishedAt?.toUtc().toIso8601String(),
+      };
+
+  factory ChampionshipRound.fromMap(Map<String, dynamic> map) {
+    final difficulty = _parseDifficulty(map['difficulty'] as String?);
+    final status = _parseStatus(map['status'] as String?);
+    return ChampionshipRound(
+      difficulty: difficulty,
+      status: status,
+      startedAt: _parseDateTime(map['startedAt']),
+      finishedAt: _parseDateTime(map['finishedAt']),
+    );
+  }
+
+  static Difficulty _parseDifficulty(String? value) {
+    if (value == null) {
+      return Difficulty.novice;
+    }
+    return Difficulty.values.firstWhere(
+      (element) => element.name == value,
+      orElse: () => Difficulty.novice,
+    );
+  }
+
+  static ChampionshipRoundStatus _parseStatus(String? value) {
+    if (value == null) {
+      return ChampionshipRoundStatus.notStarted;
+    }
+    return ChampionshipRoundStatus.values.firstWhere(
+      (element) => element.name == value,
+      orElse: () => ChampionshipRoundStatus.notStarted,
+    );
+  }
+
+  static DateTime? _parseDateTime(dynamic value) {
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value)?.toUtc();
+    }
+    return null;
+  }
+}
+
+class ChampionshipState {
+  String sessionId;
+  final List<ChampionshipRound> rounds;
+
+  ChampionshipState({
+    required this.sessionId,
+    required List<ChampionshipRound> rounds,
+  }) : rounds = List<ChampionshipRound>.from(rounds);
+
+  Map<String, dynamic> toMap() => {
+        'sessionId': sessionId,
+        'rounds': rounds.map((round) => round.toMap()).toList(),
+      };
+
+  factory ChampionshipState.fromMap(Map<String, dynamic> map) {
+    final storedRounds = map['rounds'];
+    final rounds = _createDefaultRounds();
+    if (storedRounds is List) {
+      final loadedByDifficulty = <Difficulty, ChampionshipRound>{};
+      for (final entry in storedRounds) {
+        if (entry is Map<String, dynamic>) {
+          final round = ChampionshipRound.fromMap(entry);
+          loadedByDifficulty[round.difficulty] = round;
+        } else if (entry is Map) {
+          final round = ChampionshipRound.fromMap(
+            Map<String, dynamic>.from(entry as Map),
+          );
+          loadedByDifficulty[round.difficulty] = round;
+        }
+      }
+      for (final round in rounds) {
+        final loaded = loadedByDifficulty[round.difficulty];
+        if (loaded != null) {
+          round
+            ..status = loaded.status
+            ..startedAt = loaded.startedAt
+            ..finishedAt = loaded.finishedAt;
+        }
+      }
+    }
+
+    return ChampionshipState(
+      sessionId: map['sessionId'] as String? ?? _newSessionId(),
+      rounds: rounds,
+    );
+  }
+}
+
+class ChampionshipModel extends ChangeNotifier {
+  ChampionshipModel()
+      : _state = ChampionshipState(
+          sessionId: _newSessionId(),
+          rounds: _createDefaultRounds(),
+        );
+
+  static const _prefsKey = 'championship.session.v1';
+
+  ChampionshipState _state;
+
+  String get sessionId => _state.sessionId;
+
+  List<ChampionshipRound> get rounds =>
+      List<ChampionshipRound>.unmodifiable(_state.rounds);
+
+  Future<void> loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_prefsKey);
+    if (jsonString == null) {
+      await prefs.setString(_prefsKey, jsonEncode(_state.toMap()));
+      return;
+    }
+
+    try {
+      final decoded = jsonDecode(jsonString);
+      if (decoded is Map<String, dynamic>) {
+        _state = ChampionshipState.fromMap(decoded);
+      } else if (decoded is Map) {
+        _state = ChampionshipState.fromMap(
+          Map<String, dynamic>.from(decoded as Map),
+        );
+      } else {
+        _state = ChampionshipState(
+          sessionId: _newSessionId(),
+          rounds: _createDefaultRounds(),
+        );
+        unawaited(saveToPrefs());
+      }
+      notifyListeners();
+    } catch (_) {
+      _state = ChampionshipState(
+        sessionId: _newSessionId(),
+        rounds: _createDefaultRounds(),
+      );
+      unawaited(saveToPrefs());
+      notifyListeners();
+    }
+  }
+
+  Future<void> saveToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, jsonEncode(_state.toMap()));
+  }
+
+  void startRound(Difficulty difficulty) {
+    final round = _state.rounds.firstWhere(
+      (r) => r.difficulty == difficulty,
+      orElse: () =>
+          throw ArgumentError('Unknown championship difficulty: $difficulty'),
+    );
+
+    if (round.status == ChampionshipRoundStatus.completed) {
+      return;
+    }
+
+    var changed = false;
+    if (round.status != ChampionshipRoundStatus.inProgress) {
+      round.status = ChampionshipRoundStatus.inProgress;
+      round.startedAt ??= DateTime.now().toUtc();
+      changed = true;
+    } else if (round.startedAt == null) {
+      round.startedAt = DateTime.now().toUtc();
+      changed = true;
+    }
+
+    if (changed) {
+      notifyListeners();
+      unawaited(saveToPrefs());
+    }
+  }
+
+  void completeCurrentRound() {
+    for (final round in _state.rounds.reversed) {
+      if (round.status == ChampionshipRoundStatus.inProgress) {
+        round
+          ..status = ChampionshipRoundStatus.completed
+          ..finishedAt = DateTime.now().toUtc();
+        notifyListeners();
+        unawaited(saveToPrefs());
+        break;
+      }
+    }
+  }
+
+  void resetSession() {
+    _state.sessionId = _newSessionId();
+    for (final round in _state.rounds) {
+      round
+        ..status = ChampionshipRoundStatus.notStarted
+        ..startedAt = null
+        ..finishedAt = null;
+    }
+    notifyListeners();
+    unawaited(saveToPrefs());
+  }
+}
+
+const List<Difficulty> _defaultDifficultyOrder = [
+  Difficulty.novice,
+  Difficulty.medium,
+  Difficulty.high,
+  Difficulty.expert,
+  Difficulty.master,
+];
+
+List<ChampionshipRound> _createDefaultRounds() => _defaultDifficultyOrder
+    .map((difficulty) => ChampionshipRound(difficulty: difficulty))
+    .toList(growable: false);
+
+String _newSessionId() => DateTime.now().toUtc().toIso8601String();

--- a/lib/championship/championship_page.dart
+++ b/lib/championship/championship_page.dart
@@ -5,90 +5,93 @@ import '../flutter_gen/gen_l10n/app_localizations.dart';
 import '../game_page.dart';
 import '../models.dart';
 import '../theme.dart';
+import 'championship_model.dart';
 
 class ChampionshipPage extends StatelessWidget {
   const ChampionshipPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final cs = theme.colorScheme;
-    final colors = theme.extension<SudokuColors>()!;
-    final l10n = AppLocalizations.of(context)!;
+    return Consumer<ChampionshipModel>(
+      builder: (context, championship, _) {
+        final theme = Theme.of(context);
+        final cs = theme.colorScheme;
+        final colors = theme.extension<SudokuColors>()!;
+        final l10n = AppLocalizations.of(context)!;
 
-    const difficulties = [
-      Difficulty.novice,
-      Difficulty.medium,
-      Difficulty.high,
-      Difficulty.expert,
-      Difficulty.master,
-    ];
+        final rounds = championship.rounds
+            .map(
+              (round) => _ChampionshipRoundData(
+                difficulty: round.difficulty,
+                status: round.status,
+                description: l10n.championshipRoundDescriptionPlaceholder,
+                badgeLabel: round.difficulty.shortLabel(l10n),
+              ),
+            )
+            .toList(growable: false);
 
-    final rounds = difficulties
-        .map(
-          (difficulty) => _ChampionshipRoundData(
-            difficulty: difficulty,
-            description: l10n.championshipRoundDescriptionPlaceholder,
-            badgeLabel: difficulty.shortLabel(l10n),
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(l10n.championshipTitle),
           ),
-        )
-        .toList(growable: false);
-
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.championshipTitle),
-      ),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                decoration: BoxDecoration(
-                  gradient: colors.championshipChallengeGradient,
-                  borderRadius: const BorderRadius.all(Radius.circular(24)),
-                  boxShadow: [
-                    BoxShadow(
-                      color: theme.shadowColor,
-                      blurRadius: 18,
-                      offset: const Offset(0, 10),
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                    decoration: BoxDecoration(
+                      gradient: colors.championshipChallengeGradient,
+                      borderRadius: const BorderRadius.all(Radius.circular(24)),
+                      boxShadow: [
+                        BoxShadow(
+                          color: theme.shadowColor,
+                          blurRadius: 18,
+                          offset: const Offset(0, 10),
+                        ),
+                      ],
                     ),
-                  ],
-                ),
-                child: Text(
-                  l10n.championshipScore(0),
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: cs.onPrimary,
-                    fontWeight: FontWeight.w600,
+                    child: Text(
+                      l10n.championshipScore(0),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: cs.onPrimary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ),
-                ),
+                  const SizedBox(height: 24),
+                  Expanded(
+                    child: ListView.separated(
+                      itemBuilder: (context, index) {
+                        final round = rounds[index];
+                        return _ChampionshipRoundCard(
+                          key: ValueKey('round-$index'),
+                          data: round,
+                          onAction:
+                              round.status == ChampionshipRoundStatus.completed
+                                  ? null
+                                  : () => _startRound(context, round.difficulty),
+                        );
+                      },
+                      separatorBuilder: (_, __) => const SizedBox(height: 16),
+                      itemCount: rounds.length,
+                      padding: EdgeInsets.zero,
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 24),
-              Expanded(
-                child: ListView.separated(
-                  itemBuilder: (context, index) {
-                    final round = rounds[index];
-                    return _ChampionshipRoundCard(
-                      key: ValueKey('round-$index'),
-                      data: round,
-                      onPlay: () => _startRound(context, round.difficulty),
-                    );
-                  },
-                  separatorBuilder: (_, __) => const SizedBox(height: 16),
-                  itemCount: rounds.length,
-                  padding: EdgeInsets.zero,
-                ),
-              ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 
   void _startRound(BuildContext context, Difficulty difficulty) {
+    context.read<ChampionshipModel>().startRound(difficulty);
     final app = context.read<AppState>();
     app.startGame(difficulty);
     Navigator.push(
@@ -100,11 +103,13 @@ class ChampionshipPage extends StatelessWidget {
 
 class _ChampionshipRoundData {
   final Difficulty difficulty;
+  final ChampionshipRoundStatus status;
   final String description;
   final String? badgeLabel;
 
   const _ChampionshipRoundData({
     required this.difficulty,
+    required this.status,
     required this.description,
     this.badgeLabel,
   });
@@ -112,12 +117,12 @@ class _ChampionshipRoundData {
 
 class _ChampionshipRoundCard extends StatelessWidget {
   final _ChampionshipRoundData data;
-  final VoidCallback onPlay;
+  final VoidCallback? onAction;
 
   const _ChampionshipRoundCard({
     super.key,
     required this.data,
-    required this.onPlay,
+    this.onAction,
   });
 
   @override
@@ -125,6 +130,68 @@ class _ChampionshipRoundCard extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
+
+    Widget actionChild;
+    switch (data.status) {
+      case ChampionshipRoundStatus.notStarted:
+      case ChampionshipRoundStatus.inProgress:
+        final callback = onAction;
+        if (callback == null) {
+          actionChild = const SizedBox.shrink();
+          break;
+        }
+        final label = data.status == ChampionshipRoundStatus.notStarted
+            ? l10n.playAction
+            : l10n.continueAction;
+        actionChild = ElevatedButton(
+          onPressed: callback,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: cs.primary,
+            foregroundColor: cs.onPrimary,
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(18)),
+            ),
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(fontWeight: FontWeight.w600),
+          ),
+        );
+        break;
+      case ChampionshipRoundStatus.completed:
+        actionChild = Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          decoration: BoxDecoration(
+            color: Color.alphaBlend(
+              cs.primary.withOpacity(0.12),
+              cs.surface,
+            ),
+            borderRadius: const BorderRadius.all(Radius.circular(18)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.check_circle,
+                color: cs.primary,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                l10n.championshipRoundCompletedLabel,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: cs.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        );
+        break;
+    }
 
     return Container(
       decoration: BoxDecoration(
@@ -154,7 +221,8 @@ class _ChampionshipRoundCard extends StatelessWidget {
               ),
               if (data.badgeLabel != null)
                 Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                   decoration: BoxDecoration(
                     color: Color.alphaBlend(
                       cs.primary.withOpacity(0.12),
@@ -182,21 +250,7 @@ class _ChampionshipRoundCard extends StatelessWidget {
           const SizedBox(height: 18),
           SizedBox(
             height: 40,
-            child: ElevatedButton(
-              onPressed: onPlay,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: cs.primary,
-                foregroundColor: cs.onPrimary,
-                padding: const EdgeInsets.symmetric(horizontal: 24),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.all(Radius.circular(18)),
-                ),
-              ),
-              child: Text(
-                l10n.playAction,
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
-            ),
+            child: actionChild,
           ),
         ],
       ),

--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -64,6 +64,8 @@ abstract class AppLocalizations {
 
   String get championshipRoundDescriptionPlaceholder;
 
+  String get championshipRoundCompletedLabel;
+
   String get battleTitle;
 
   String battleWinRate(int percent);
@@ -344,6 +346,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get championshipRoundDescriptionPlaceholder => "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.";
+
+  @override
+  String get championshipRoundCompletedLabel => "Abgeschlossen";
 
   @override
   String get battleTitle => "Duell";
@@ -692,6 +697,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get championshipRoundDescriptionPlaceholder => "Play this round to boost your championship run.";
 
   @override
+  String get championshipRoundCompletedLabel => "Completed";
+
+  @override
   String get battleTitle => "Battle";
 
   @override
@@ -1036,6 +1044,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipRoundDescriptionPlaceholder => "Jouez cette manche pour booster votre parcours au championnat.";
+
+  @override
+  String get championshipRoundCompletedLabel => "Terminé";
 
   @override
   String get battleTitle => "Duel";
@@ -1384,6 +1395,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get championshipRoundDescriptionPlaceholder => "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।";
 
   @override
+  String get championshipRoundCompletedLabel => "पूरा हुआ";
+
+  @override
   String get battleTitle => "बैटल";
 
   @override
@@ -1728,6 +1742,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get championshipRoundDescriptionPlaceholder => "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.";
+
+  @override
+  String get championshipRoundCompletedLabel => "Завершено";
 
   @override
   String get battleTitle => "Битва";
@@ -2080,6 +2097,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get championshipRoundDescriptionPlaceholder => "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.";
 
   @override
+  String get championshipRoundCompletedLabel => "Завершено";
+
+  @override
   String get battleTitle => "Битва";
 
   @override
@@ -2428,6 +2448,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get championshipRoundDescriptionPlaceholder => "进行这一轮，推动你的锦标赛征程。";
+
+  @override
+  String get championshipRoundCompletedLabel => "已完成";
 
   @override
   String get battleTitle => "对战";

--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'championship/championship_model.dart';
 import 'models.dart';
 import 'settings_page.dart';
 import 'theme.dart';
@@ -211,6 +212,10 @@ class _GamePageState extends State<GamePage> with WidgetsBindingObserver {
       if (!_victoryShown) {
         _victoryShown = true;
         _showVictoryDialog(app);
+        try {
+          // після успішного завершення гри
+          context.read<ChampionshipModel?>()?.completeCurrentRound();
+        } catch (_) {}
       }
     } else if (app.isOutOfLives) {
       if (!_failureShown) {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.",
+  "championshipRoundCompletedLabel": "Abgeschlossen",
   "battleTitle": "Duell",
   "battleWinRate": "Siegquote {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "Play this round to boost your championship run.",
+  "championshipRoundCompletedLabel": "Completed",
   "battleTitle": "Battle",
   "battleWinRate": "Win rate {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "Jouez cette manche pour booster votre parcours au championnat.",
+  "championshipRoundCompletedLabel": "Terminé",
   "battleTitle": "Duel",
   "battleWinRate": "Taux de victoire {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।",
+  "championshipRoundCompletedLabel": "पूरा हुआ",
   "battleTitle": "बैटल",
   "battleWinRate": "जीत दर {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.",
+  "championshipRoundCompletedLabel": "Завершено",
   "battleTitle": "Битва",
   "battleWinRate": "Процент побед {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.",
+  "championshipRoundCompletedLabel": "Завершено",
   "battleTitle": "Битва",
   "battleWinRate": "Відсоток перемог {percent}%",
   "@battleWinRate": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -18,6 +18,7 @@
     }
   },
   "championshipRoundDescriptionPlaceholder": "进行这一轮，推动你的锦标赛征程。",
+  "championshipRoundCompletedLabel": "已完成",
   "battleTitle": "对战",
   "battleWinRate": "胜率 {percent}%",
   "@battleWinRate": {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'championship/championship_model.dart';
 import 'championship/championship_page.dart';
 import 'home_screen.dart';
 import 'models.dart';
@@ -25,6 +26,10 @@ Future<void> main() async {
     MultiProvider(
       providers: [
         ChangeNotifierProvider.value(value: appState),
+        ChangeNotifierProvider<ChampionshipModel>(
+          create: (_) => ChampionshipModel()..loadFromPrefs(),
+          lazy: false,
+        ),
         ChangeNotifierProvider(create: (_) => UndoAdController()),
       ],
       child: const SudokuApp(),


### PR DESCRIPTION
## Summary
- add a championship state model with persistent session/round tracking
- expose the model via provider and update the championship page actions and statuses
- mark rounds as completed after victories and localize the completed label

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3df2d694832689a5cd3dc052700c