### PR TITLE
Improve championship UX and scoring reliability

### DIFF
--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -70,6 +70,14 @@ abstract class AppLocalizations {
 
   String get meLabel;
 
+  String leaderboardRow(int rank, String name, String points);
+
+  String yourPosition(int rank, String points);
+
+  String get pointsShort;
+
+  String get championshipAutoScroll;
+
   String get play;
 
   String get battleTitle;
@@ -363,6 +371,22 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get meLabel => "Ich";
+
+  @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "Platz ${rank}, ${name}, ${points} Punkte";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "Mein Platz ${rank}, ${points} Punkte";
+  }
+
+  @override
+  String get pointsShort => "Pkt.";
+
+  @override
+  String get championshipAutoScroll => "Automatisch zu meiner Position scrollen";
 
   @override
   String get play => "Spielen";
@@ -725,6 +749,22 @@ class AppLocalizationsEn extends AppLocalizations {
   String get meLabel => "Me";
 
   @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "Place ${rank}, ${name}, ${points} points";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "My place ${rank}, ${points} points";
+  }
+
+  @override
+  String get pointsShort => "pts";
+
+  @override
+  String get championshipAutoScroll => "Auto-scroll to my position";
+
+  @override
   String get play => "Play";
 
   @override
@@ -1083,6 +1123,22 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get meLabel => "Moi";
+
+  @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "Position ${rank}, ${name}, ${points} points";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "Ma position ${rank}, ${points} points";
+  }
+
+  @override
+  String get pointsShort => "pts";
+
+  @override
+  String get championshipAutoScroll => "Défilement auto vers ma position";
 
   @override
   String get play => "Jouer";
@@ -1445,6 +1501,22 @@ class AppLocalizationsHi extends AppLocalizations {
   String get meLabel => "मैं";
 
   @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "स्थान ${rank}, ${name}, ${points} अंक";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "मेरा स्थान ${rank}, ${points} अंक";
+  }
+
+  @override
+  String get pointsShort => "अंक";
+
+  @override
+  String get championshipAutoScroll => "मेरी स्थिति तक स्वतः स्क्रॉल करें";
+
+  @override
   String get play => "खेलें";
 
   @override
@@ -1803,6 +1875,22 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get meLabel => "Я";
+
+  @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "Место ${rank}, ${name}, ${points} очков";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "Моё место ${rank}, ${points} очков";
+  }
+
+  @override
+  String get pointsShort => "очк.";
+
+  @override
+  String get championshipAutoScroll => "Автопрокрутка к моему месту";
 
   @override
   String get play => "Играть";
@@ -2169,6 +2257,22 @@ class AppLocalizationsUk extends AppLocalizations {
   String get meLabel => "Я";
 
   @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "Місце ${rank}, ${name}, ${points} очок";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "Моє місце ${rank}, ${points} очок";
+  }
+
+  @override
+  String get pointsShort => "оч.";
+
+  @override
+  String get championshipAutoScroll => "Автоскрол до мого місця";
+
+  @override
   String get play => "Грати";
 
   @override
@@ -2531,6 +2635,22 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get meLabel => "我";
+
+  @override
+  String leaderboardRow(int rank, String name, String points) {
+    return "第${rank}名，${name}，${points} 分";
+  }
+
+  @override
+  String yourPosition(int rank, String points) {
+    return "我的排名第${rank}名，${points} 分";
+  }
+
+  @override
+  String get pointsShort => "分";
+
+  @override
+  String get championshipAutoScroll => "自动滚动到我的位置";
 
   @override
   String get play => "游玩";

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "Ich",
+  "leaderboardRow": "Platz {rank}, {name}, {points} Punkte",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "Mein Platz {rank}, {points} Punkte",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "Pkt.",
+  "championshipAutoScroll": "Automatisch zu meiner Position scrollen",
   "play": "Spielen",
   "battleTitle": "Duell",
   "battleWinRate": "Siegquote {percent}%",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "Me",
+  "leaderboardRow": "Place {rank}, {name}, {points} points",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "My place {rank}, {points} points",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "pts",
+  "championshipAutoScroll": "Auto-scroll to my position",
   "play": "Play",
   "battleTitle": "Battle",
   "battleWinRate": "Win rate {percent}%",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "Moi",
+  "leaderboardRow": "Position {rank}, {name}, {points} points",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "Ma position {rank}, {points} points",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "pts",
+  "championshipAutoScroll": "Défilement auto vers ma position",
   "play": "Jouer",
   "battleTitle": "Duel",
   "battleWinRate": "Taux de victoire {percent}%",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "मैं",
+  "leaderboardRow": "स्थान {rank}, {name}, {points} अंक",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "मेरा स्थान {rank}, {points} अंक",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "अंक",
+  "championshipAutoScroll": "मेरी स्थिति तक स्वतः स्क्रॉल करें",
   "play": "खेलें",
   "battleTitle": "बैटल",
   "battleWinRate": "जीत दर {percent}%",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "Я",
+  "leaderboardRow": "Место {rank}, {name}, {points} очков",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "Моё место {rank}, {points} очков",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "очк.",
+  "championshipAutoScroll": "Автопрокрутка к моему месту",
   "play": "Играть",
   "battleTitle": "Битва",
   "battleWinRate": "Процент побед {percent}%",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "Я",
+  "leaderboardRow": "Місце {rank}, {name}, {points} очок",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "Моє місце {rank}, {points} очок",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "оч.",
+  "championshipAutoScroll": "Автоскрол до мого місця",
   "play": "Грати",
   "battleTitle": "Битва",
   "battleWinRate": "Відсоток перемог {percent}%",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -28,6 +28,33 @@
     }
   },
   "meLabel": "我",
+  "leaderboardRow": "第{rank}名，{name}，{points} 分",
+  "@leaderboardRow": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "name": {
+        "type": "String"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "yourPosition": "我的排名第{rank}名，{points} 分",
+  "@yourPosition": {
+    "placeholders": {
+      "rank": {
+        "type": "int"
+      },
+      "points": {
+        "type": "String"
+      }
+    }
+  },
+  "pointsShort": "分",
+  "championshipAutoScroll": "自动滚动到我的位置",
   "play": "游玩",
   "battleTitle": "对战",
   "battleWinRate": "胜率 {percent}%",

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'championship/championship_model.dart';
 import 'models.dart';
 import 'widgets/theme_menu.dart';
 
@@ -15,6 +16,7 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final app = context.watch<AppState>();
+    final championship = context.watch<ChampionshipModel>();
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
@@ -71,6 +73,13 @@ class SettingsPage extends StatelessWidget {
             value: app.musicEnabled,
             onChanged: (v) => app.toggleMusic(v),
             secondary: const Icon(Icons.music_note),
+          ),
+          SwitchListTile(
+            key: const ValueKey('settings-champ-auto-scroll'),
+            title: Text(l10n.championshipAutoScroll),
+            value: championship.autoScrollEnabled,
+            onChanged: (v) => championship.setAutoScrollEnabled(v),
+            secondary: const Icon(Icons.my_location_alt),
           ),
           const Divider(height: 32),
 


### PR DESCRIPTION
## Summary
- add persisted auto-scroll setting, leaderboard animation, and accessibility semantics for the championship list
- show score gain toast with optional haptics, prevent duplicate score awards, and persist game identifiers
- expose auto-scroll toggle in settings and update localizations for new strings

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd48cac77c8326bd4fee3bf1b86b96