### PR TITLE
Add championship progress indicators and offline data tools

### DIFF
--- a/lib/championship/championship_backup.dart
+++ b/lib/championship/championship_backup.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+class ChampionshipBackupData {
+  const ChampionshipBackupData({
+    required this.version,
+    required this.exportedAt,
+    required this.myScore,
+    required this.bestRank,
+    required this.bestScore,
+    required this.installSeed,
+    required this.lastAwardedGameId,
+    required this.autoScroll,
+    required this.opponents,
+  });
+
+  static const int currentVersion = 1;
+
+  final int version;
+  final DateTime exportedAt;
+  final int myScore;
+  final int bestRank;
+  final int bestScore;
+  final int installSeed;
+  final String? lastAwardedGameId;
+  final bool autoScroll;
+  final List<Map<String, dynamic>> opponents;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'version': version,
+      'exportedAt': exportedAt.toUtc().toIso8601String(),
+      'myScore': myScore,
+      'bestRank': bestRank,
+      'bestScore': bestScore,
+      'installSeed': installSeed,
+      'lastAwardedGameId': lastAwardedGameId,
+      'settings': <String, dynamic>{'autoScroll': autoScroll},
+      'opponents': opponents,
+    };
+  }
+
+  static ChampionshipBackupData fromJson(Map<String, dynamic> json) {
+    final version = (json['version'] as num?)?.toInt();
+    if (version == null) {
+      throw const FormatException('Missing version');
+    }
+    if (version != currentVersion) {
+      throw FormatException('Unsupported backup version: $version');
+    }
+    final exportedAtRaw = json['exportedAt'] as String?;
+    final exportedAt = exportedAtRaw != null
+        ? DateTime.tryParse(exportedAtRaw)?.toUtc()
+        : null;
+    if (exportedAt == null) {
+      throw const FormatException('Invalid exportedAt');
+    }
+
+    final myScore = (json['myScore'] as num?)?.toInt();
+    final bestRank = (json['bestRank'] as num?)?.toInt();
+    final bestScore = (json['bestScore'] as num?)?.toInt();
+    final installSeed = (json['installSeed'] as num?)?.toInt();
+    if (myScore == null || bestRank == null || bestScore == null || installSeed == null) {
+      throw const FormatException('Missing numeric fields');
+    }
+
+    final settings = json['settings'];
+    final autoScroll = settings is Map
+        ? (settings['autoScroll'] as bool?) ?? true
+        : true;
+
+    final opponentsRaw = json['opponents'];
+    if (opponentsRaw is! List) {
+      throw const FormatException('Opponents should be a list');
+    }
+    final opponents = <Map<String, dynamic>>[];
+    for (final item in opponentsRaw) {
+      if (item is Map<String, dynamic>) {
+        opponents.add(Map<String, dynamic>.from(item));
+      } else if (item is Map) {
+        opponents.add(Map<String, dynamic>.from(item.cast<dynamic, dynamic>()));
+      }
+    }
+
+    return ChampionshipBackupData(
+      version: version,
+      exportedAt: exportedAt,
+      myScore: myScore,
+      bestRank: bestRank,
+      bestScore: bestScore,
+      installSeed: installSeed,
+      lastAwardedGameId: json['lastAwardedGameId'] as String?,
+      autoScroll: autoScroll,
+      opponents: List<Map<String, dynamic>>.unmodifiable(opponents),
+    );
+  }
+}
+
+class ChampionshipBackupManager {
+  static const String backupFileName = 'champ_backup_v1.json';
+
+  static Future<File> saveBackup(ChampionshipBackupData data) async {
+    if (kIsWeb) {
+      throw UnsupportedError('File system is not available on the web');
+    }
+    final directory = await getApplicationDocumentsDirectory();
+    final path = '${directory.path}/$backupFileName';
+    final file = File(path);
+    final encoded = jsonEncode(data.toJson());
+    return file.writeAsString(encoded);
+  }
+
+  static Future<ChampionshipBackupData> loadFromFile(File file) async {
+    final source = await file.readAsString();
+    return decode(source);
+  }
+
+  static ChampionshipBackupData decode(String source) {
+    final decoded = jsonDecode(source);
+    if (decoded is Map<String, dynamic>) {
+      return ChampionshipBackupData.fromJson(decoded);
+    }
+    if (decoded is Map) {
+      return ChampionshipBackupData.fromJson(
+        Map<String, dynamic>.from(decoded.cast<dynamic, dynamic>()),
+      );
+    }
+    throw const FormatException('Invalid backup format');
+  }
+}
+

--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -62,6 +62,10 @@ abstract class AppLocalizations {
 
   String championshipScore(int score);
 
+  String toNextPlace(int points);
+
+  String get youAreTop;
+
   String get championshipRoundDescriptionPlaceholder;
 
   String get championshipRoundCompletedLabel;
@@ -77,6 +81,8 @@ abstract class AppLocalizations {
   String get pointsShort;
 
   String get championshipAutoScroll;
+
+  String get bestLabel;
 
   String get play;
 
@@ -200,6 +206,8 @@ abstract class AppLocalizations {
 
   String get miscSectionTitle;
 
+  String get championshipLocalSection;
+
   String get hideCompletedNumbersLabel;
 
   String get aboutApp;
@@ -221,6 +229,24 @@ abstract class AppLocalizations {
   String get languageChinese;
 
   String get languageHindi;
+
+  String get export;
+
+  String get import;
+
+  String get resetMyScore;
+
+  String get regenerateOpponents;
+
+  String get confirm;
+
+  String get cancel;
+
+  String get done;
+
+  String get failed;
+
+  String rankBadgeChasing(int current, int delta, int target);
 
   String get statsTitle;
 
@@ -359,6 +385,14 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "Bis zum nächsten Platz: ${points} Pkt";
+  }
+
+  @override
+  String get youAreTop => "Du bist Nr. 1";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.";
 
   @override
@@ -374,12 +408,12 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "Platz ${rank}, ${name}, ${points} Punkte";
+    return "Platz ${rank}. ${name}. ${points} Punkte";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "Mein Platz ${rank}, ${points} Punkte";
+    return "Mein Platz ${rank}. ${points} Punkte";
   }
 
   @override
@@ -387,6 +421,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "Automatisch zu meiner Position scrollen";
+
+  @override
+  String get bestLabel => "Bestleistung";
 
   @override
   String get play => "Spielen";
@@ -598,6 +635,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get miscSectionTitle => "Sonstiges";
 
   @override
+  String get championshipLocalSection => "Meisterschaft (lokal)";
+
+  @override
   String get hideCompletedNumbersLabel => "Verwendete Ziffern ausblenden";
 
   @override
@@ -631,6 +671,35 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "Exportieren";
+
+  @override
+  String get import => "Importieren";
+
+  @override
+  String get resetMyScore => "Meinen Punktestand zurücksetzen";
+
+  @override
+  String get regenerateOpponents => "Gegner neu erstellen";
+
+  @override
+  String get confirm => "Bestätigen";
+
+  @override
+  String get cancel => "Abbrechen";
+
+  @override
+  String get done => "Fertig";
+
+  @override
+  String get failed => "Fehlgeschlagen";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "Rang #${current} • +${delta} bis #${target}";
+  }
 
   @override
   String get statsTitle => "Statistiken";
@@ -735,6 +804,22 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "Jusqu'à la prochaine place : ${points} pts";
+  }
+
+  @override
+  String get youAreTop => "Vous êtes n°1";
+
+  @override
+  String toNextPlace(int points) {
+    return "To next place: ${points} pts";
+  }
+
+  @override
+  String get youAreTop => "You are #1";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "Play this round to boost your championship run.";
 
   @override
@@ -750,12 +835,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "Place ${rank}, ${name}, ${points} points";
+    return "Place ${rank}. ${name}. ${points} points";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "My place ${rank}, ${points} points";
+    return "My place ${rank}. ${points} points";
   }
 
   @override
@@ -763,6 +848,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "Auto-scroll to my position";
+
+  @override
+  String get bestLabel => "Best";
 
   @override
   String get play => "Play";
@@ -974,6 +1062,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get miscSectionTitle => "Other";
 
   @override
+  String get championshipLocalSection => "Championship (local)";
+
+  @override
   String get hideCompletedNumbersLabel => "Hide completed digits";
 
   @override
@@ -1007,6 +1098,35 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "Export";
+
+  @override
+  String get import => "Import";
+
+  @override
+  String get resetMyScore => "Reset my score";
+
+  @override
+  String get regenerateOpponents => "Regenerate opponents";
+
+  @override
+  String get confirm => "Confirm";
+
+  @override
+  String get cancel => "Cancel";
+
+  @override
+  String get done => "Done";
+
+  @override
+  String get failed => "Failed";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "Rank #${current} • +${delta} to #${target}";
+  }
 
   @override
   String get statsTitle => "Statistics";
@@ -1126,12 +1246,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "Position ${rank}, ${name}, ${points} points";
+    return "Place ${rank}. ${name}. ${points} points";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "Ma position ${rank}, ${points} points";
+    return "Ma place ${rank}. ${points} points";
   }
 
   @override
@@ -1139,6 +1259,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "Défilement auto vers ma position";
+
+  @override
+  String get bestLabel => "Meilleur";
 
   @override
   String get play => "Jouer";
@@ -1350,6 +1473,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get miscSectionTitle => "Autre";
 
   @override
+  String get championshipLocalSection => "Championnat (local)";
+
+  @override
   String get hideCompletedNumbersLabel => "Masquer les chiffres utilisés";
 
   @override
@@ -1383,6 +1509,35 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "Exporter";
+
+  @override
+  String get import => "Importer";
+
+  @override
+  String get resetMyScore => "Réinitialiser mon score";
+
+  @override
+  String get regenerateOpponents => "Régénérer les adversaires";
+
+  @override
+  String get confirm => "Confirmer";
+
+  @override
+  String get cancel => "Annuler";
+
+  @override
+  String get done => "Terminé";
+
+  @override
+  String get failed => "Échec";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "Rang #${current} • +${delta} vers #${target}";
+  }
 
   @override
   String get statsTitle => "Statistiques";
@@ -1487,6 +1642,14 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "अगले स्थान तक: ${points} अंक";
+  }
+
+  @override
+  String get youAreTop => "आप नं. 1 हैं";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।";
 
   @override
@@ -1502,12 +1665,12 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "स्थान ${rank}, ${name}, ${points} अंक";
+    return "स्थान ${rank}. ${name}. ${points} अंक";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "मेरा स्थान ${rank}, ${points} अंक";
+    return "मेरा स्थान ${rank}. ${points} अंक";
   }
 
   @override
@@ -1515,6 +1678,9 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "मेरी स्थिति तक स्वतः स्क्रॉल करें";
+
+  @override
+  String get bestLabel => "श्रेष्ठ";
 
   @override
   String get play => "खेलें";
@@ -1726,6 +1892,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get miscSectionTitle => "अन्य";
 
   @override
+  String get championshipLocalSection => "चैम्पियनशिप (स्थानीय)";
+
+  @override
   String get hideCompletedNumbersLabel => "प्रयुक्त अंकों को छुपाएँ";
 
   @override
@@ -1759,6 +1928,35 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "निर्यात";
+
+  @override
+  String get import => "आयात";
+
+  @override
+  String get resetMyScore => "मेरा स्कोर रीसेट करें";
+
+  @override
+  String get regenerateOpponents => "प्रतिद्वंद्वी पुनः उत्पन्न करें";
+
+  @override
+  String get confirm => "पुष्टि करें";
+
+  @override
+  String get cancel => "रद्द करें";
+
+  @override
+  String get done => "पूर्ण";
+
+  @override
+  String get failed => "असफल";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "रैंक #${current} • +${delta} से #${target}";
+  }
 
   @override
   String get statsTitle => "आँकड़े";
@@ -1863,6 +2061,14 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "До следующего места: ${points} оч.";
+  }
+
+  @override
+  String get youAreTop => "Вы №1";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.";
 
   @override
@@ -1878,12 +2084,12 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "Место ${rank}, ${name}, ${points} очков";
+    return "Место ${rank}. ${name}. ${points} очков";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "Моё место ${rank}, ${points} очков";
+    return "Моё место ${rank}. ${points} очков";
   }
 
   @override
@@ -1891,6 +2097,9 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "Автопрокрутка к моему месту";
+
+  @override
+  String get bestLabel => "Лучший результат";
 
   @override
   String get play => "Играть";
@@ -2106,6 +2315,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get miscSectionTitle => "Другое";
 
   @override
+  String get championshipLocalSection => "Чемпионат (локально)";
+
+  @override
   String get hideCompletedNumbersLabel => "Убирать использованные цифры";
 
   @override
@@ -2139,6 +2351,35 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "Экспорт";
+
+  @override
+  String get import => "Импорт";
+
+  @override
+  String get resetMyScore => "Сбросить мой счёт";
+
+  @override
+  String get regenerateOpponents => "Перегенерировать соперников";
+
+  @override
+  String get confirm => "Подтвердить";
+
+  @override
+  String get cancel => "Отмена";
+
+  @override
+  String get done => "Готово";
+
+  @override
+  String get failed => "Ошибка";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "Место #${current} • +${delta} до #${target}";
+  }
 
   @override
   String get statsTitle => "Статистика";
@@ -2243,6 +2484,14 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "До наступного місця: ${points} оч.";
+  }
+
+  @override
+  String get youAreTop => "Ви №1";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.";
 
   @override
@@ -2258,12 +2507,12 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "Місце ${rank}, ${name}, ${points} очок";
+    return "Місце ${rank}. ${name}. ${points} очок";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "Моє місце ${rank}, ${points} очок";
+    return "Моє місце ${rank}. ${points} очок";
   }
 
   @override
@@ -2271,6 +2520,9 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "Автоскрол до мого місця";
+
+  @override
+  String get bestLabel => "Найкращий результат";
 
   @override
   String get play => "Грати";
@@ -2486,6 +2738,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get miscSectionTitle => "Інше";
 
   @override
+  String get championshipLocalSection => "Чемпіонат (локально)";
+
+  @override
   String get hideCompletedNumbersLabel => "Прибирати використані цифри";
 
   @override
@@ -2519,6 +2774,35 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "Експорт";
+
+  @override
+  String get import => "Імпорт";
+
+  @override
+  String get resetMyScore => "Скинути мій рахунок";
+
+  @override
+  String get regenerateOpponents => "Перегенерувати суперників";
+
+  @override
+  String get confirm => "Підтвердити";
+
+  @override
+  String get cancel => "Скасувати";
+
+  @override
+  String get done => "Готово";
+
+  @override
+  String get failed => "Помилка";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "Місце #${current} • +${delta} до #${target}";
+  }
 
   @override
   String get statsTitle => "Статистика";
@@ -2623,6 +2907,14 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String toNextPlace(int points) {
+    return "距下一名还差 ${points} 分";
+  }
+
+  @override
+  String get youAreTop => "您是第 1 名";
+
+  @override
   String get championshipRoundDescriptionPlaceholder => "进行这一轮，推动你的锦标赛征程。";
 
   @override
@@ -2638,12 +2930,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String leaderboardRow(int rank, String name, String points) {
-    return "第${rank}名，${name}，${points} 分";
+    return "第 ${rank} 名。${name}。${points} 分";
   }
 
   @override
   String yourPosition(int rank, String points) {
-    return "我的排名第${rank}名，${points} 分";
+    return "我的名次 ${rank}。${points} 分";
   }
 
   @override
@@ -2651,6 +2943,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get championshipAutoScroll => "自动滚动到我的位置";
+
+  @override
+  String get bestLabel => "最佳成绩";
 
   @override
   String get play => "游玩";
@@ -2860,6 +3155,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get miscSectionTitle => "其他";
 
   @override
+  String get championshipLocalSection => "锦标赛（本地）";
+
+  @override
   String get hideCompletedNumbersLabel => "隐藏已用数字";
 
   @override
@@ -2893,6 +3191,35 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get languageHindi => "हिन्दी";
+
+  @override
+  String get export => "导出";
+
+  @override
+  String get import => "导入";
+
+  @override
+  String get resetMyScore => "重置我的得分";
+
+  @override
+  String get regenerateOpponents => "重新生成对手";
+
+  @override
+  String get confirm => "确认";
+
+  @override
+  String get cancel => "取消";
+
+  @override
+  String get done => "完成";
+
+  @override
+  String get failed => "失败";
+
+  @override
+  String rankBadgeChasing(int current, int delta, int target) {
+    return "第 ${current} 名 • 还差 ${delta} 分到第 ${target} 名";
+  }
 
   @override
   String get statsTitle => "统计";

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "Bis zum nächsten Platz: {points} Pkt",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "Du bist Nr. 1",
   "championshipRoundDescriptionPlaceholder": "Spiele diese Runde, um deinen Meisterschaftslauf zu stärken.",
   "championshipRoundCompletedLabel": "Abgeschlossen",
   "totalScore": "Gesamtpunktzahl: {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "Ich",
-  "leaderboardRow": "Platz {rank}, {name}, {points} Punkte",
+  "leaderboardRow": "Platz {rank}. {name}. {points} Punkte",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "Mein Platz {rank}, {points} Punkte",
+  "yourPosition": "Mein Platz {rank}. {points} Punkte",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "Pkt.",
   "championshipAutoScroll": "Automatisch zu meiner Position scrollen",
+  "bestLabel": "Bestleistung",
   "play": "Spielen",
   "battleTitle": "Duell",
   "battleWinRate": "Siegquote {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "Vibration",
   "musicLabel": "Hintergrundmusik",
   "miscSectionTitle": "Sonstiges",
+  "championshipLocalSection": "Meisterschaft (lokal)",
   "hideCompletedNumbersLabel": "Verwendete Ziffern ausblenden",
   "aboutApp": "Über",
   "versionLabel": "Version {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "Exportieren",
+  "import": "Importieren",
+  "resetMyScore": "Meinen Punktestand zurücksetzen",
+  "regenerateOpponents": "Gegner neu erstellen",
+  "confirm": "Bestätigen",
+  "cancel": "Abbrechen",
+  "done": "Fertig",
+  "failed": "Fehlgeschlagen",
+  "rankBadgeChasing": "Rang #{current} • +{delta} bis #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "Statistiken",
   "statsGamesSection": "Spiele",
   "statsGamesStarted": "Gestartete Spiele",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "To next place: {points} pts",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "You are #1",
   "championshipRoundDescriptionPlaceholder": "Play this round to boost your championship run.",
   "championshipRoundCompletedLabel": "Completed",
   "totalScore": "Total score: {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "Me",
-  "leaderboardRow": "Place {rank}, {name}, {points} points",
+  "leaderboardRow": "Place {rank}. {name}. {points} points",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "My place {rank}, {points} points",
+  "yourPosition": "My place {rank}. {points} points",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "pts",
   "championshipAutoScroll": "Auto-scroll to my position",
+  "bestLabel": "Best",
   "play": "Play",
   "battleTitle": "Battle",
   "battleWinRate": "Win rate {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "Vibration",
   "musicLabel": "Background music",
   "miscSectionTitle": "Other",
+  "championshipLocalSection": "Championship (local)",
   "hideCompletedNumbersLabel": "Hide completed digits",
   "aboutApp": "About",
   "versionLabel": "Version {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "Export",
+  "import": "Import",
+  "resetMyScore": "Reset my score",
+  "regenerateOpponents": "Regenerate opponents",
+  "confirm": "Confirm",
+  "cancel": "Cancel",
+  "done": "Done",
+  "failed": "Failed",
+  "rankBadgeChasing": "Rank #{current} • +{delta} to #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "Statistics",
   "statsGamesSection": "Games",
   "statsGamesStarted": "Games started",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "Jusqu'à la prochaine place : {points} pts",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "Vous êtes n°1",
   "championshipRoundDescriptionPlaceholder": "Jouez cette manche pour booster votre parcours au championnat.",
   "championshipRoundCompletedLabel": "Terminé",
   "totalScore": "Score total : {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "Moi",
-  "leaderboardRow": "Position {rank}, {name}, {points} points",
+  "leaderboardRow": "Place {rank}. {name}. {points} points",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "Ma position {rank}, {points} points",
+  "yourPosition": "Ma place {rank}. {points} points",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "pts",
   "championshipAutoScroll": "Défilement auto vers ma position",
+  "bestLabel": "Meilleur",
   "play": "Jouer",
   "battleTitle": "Duel",
   "battleWinRate": "Taux de victoire {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "Vibration",
   "musicLabel": "Musique de fond",
   "miscSectionTitle": "Autre",
+  "championshipLocalSection": "Championnat (local)",
   "hideCompletedNumbersLabel": "Masquer les chiffres utilisés",
   "aboutApp": "À propos",
   "versionLabel": "Version {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "Exporter",
+  "import": "Importer",
+  "resetMyScore": "Réinitialiser mon score",
+  "regenerateOpponents": "Régénérer les adversaires",
+  "confirm": "Confirmer",
+  "cancel": "Annuler",
+  "done": "Terminé",
+  "failed": "Échec",
+  "rankBadgeChasing": "Rang #{current} • +{delta} vers #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "Statistiques",
   "statsGamesSection": "Parties",
   "statsGamesStarted": "Parties lancées",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "अगले स्थान तक: {points} अंक",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "आप नं. 1 हैं",
   "championshipRoundDescriptionPlaceholder": "इस राउंड को खेलें और अपने चैम्पियनशिप सफर को आगे बढ़ाएँ।",
   "championshipRoundCompletedLabel": "पूरा हुआ",
   "totalScore": "कुल स्कोर: {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "मैं",
-  "leaderboardRow": "स्थान {rank}, {name}, {points} अंक",
+  "leaderboardRow": "स्थान {rank}. {name}. {points} अंक",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "मेरा स्थान {rank}, {points} अंक",
+  "yourPosition": "मेरा स्थान {rank}. {points} अंक",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "अंक",
   "championshipAutoScroll": "मेरी स्थिति तक स्वतः स्क्रॉल करें",
+  "bestLabel": "श्रेष्ठ",
   "play": "खेलें",
   "battleTitle": "बैटल",
   "battleWinRate": "जीत दर {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "कंपन",
   "musicLabel": "पृष्ठभूमि संगीत",
   "miscSectionTitle": "अन्य",
+  "championshipLocalSection": "चैम्पियनशिप (स्थानीय)",
   "hideCompletedNumbersLabel": "प्रयुक्त अंकों को छुपाएँ",
   "aboutApp": "ऐप के बारे में",
   "versionLabel": "संस्करण {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "निर्यात",
+  "import": "आयात",
+  "resetMyScore": "मेरा स्कोर रीसेट करें",
+  "regenerateOpponents": "प्रतिद्वंद्वी पुनः उत्पन्न करें",
+  "confirm": "पुष्टि करें",
+  "cancel": "रद्द करें",
+  "done": "पूर्ण",
+  "failed": "असफल",
+  "rankBadgeChasing": "रैंक #{current} • +{delta} से #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "आँकड़े",
   "statsGamesSection": "खेल",
   "statsGamesStarted": "शुरू किए गए खेल",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "До следующего места: {points} оч.",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "Вы №1",
   "championshipRoundDescriptionPlaceholder": "Сыграйте в этом раунде, чтобы продвинуться в чемпионате.",
   "championshipRoundCompletedLabel": "Завершено",
   "totalScore": "Общий счёт: {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "Я",
-  "leaderboardRow": "Место {rank}, {name}, {points} очков",
+  "leaderboardRow": "Место {rank}. {name}. {points} очков",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "Моё место {rank}, {points} очков",
+  "yourPosition": "Моё место {rank}. {points} очков",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "очк.",
   "championshipAutoScroll": "Автопрокрутка к моему месту",
+  "bestLabel": "Лучший результат",
   "play": "Играть",
   "battleTitle": "Битва",
   "battleWinRate": "Процент побед {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "Вибрация",
   "musicLabel": "Фоновая музыка",
   "miscSectionTitle": "Другое",
+  "championshipLocalSection": "Чемпионат (локально)",
   "hideCompletedNumbersLabel": "Убирать использованные цифры",
   "aboutApp": "О приложении",
   "versionLabel": "Версия {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "Экспорт",
+  "import": "Импорт",
+  "resetMyScore": "Сбросить мой счёт",
+  "regenerateOpponents": "Перегенерировать соперников",
+  "confirm": "Подтвердить",
+  "cancel": "Отмена",
+  "done": "Готово",
+  "failed": "Ошибка",
+  "rankBadgeChasing": "Место #{current} • +{delta} до #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "Статистика",
   "statsGamesSection": "Игры",
   "statsGamesStarted": "Начатые игры",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "До наступного місця: {points} оч.",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "Ви №1",
   "championshipRoundDescriptionPlaceholder": "Зіграйте в цьому раунді, щоб просунутися в чемпіонаті.",
   "championshipRoundCompletedLabel": "Завершено",
   "totalScore": "Загальний рахунок: {score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "Я",
-  "leaderboardRow": "Місце {rank}, {name}, {points} очок",
+  "leaderboardRow": "Місце {rank}. {name}. {points} очок",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "Моє місце {rank}, {points} очок",
+  "yourPosition": "Моє місце {rank}. {points} очок",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "оч.",
   "championshipAutoScroll": "Автоскрол до мого місця",
+  "bestLabel": "Найкращий результат",
   "play": "Грати",
   "battleTitle": "Битва",
   "battleWinRate": "Відсоток перемог {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "Вібрація",
   "musicLabel": "Фонова музика",
   "miscSectionTitle": "Інше",
+  "championshipLocalSection": "Чемпіонат (локально)",
   "hideCompletedNumbersLabel": "Прибирати використані цифри",
   "aboutApp": "Про застосунок",
   "versionLabel": "Версія {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "Експорт",
+  "import": "Імпорт",
+  "resetMyScore": "Скинути мій рахунок",
+  "regenerateOpponents": "Перегенерувати суперників",
+  "confirm": "Підтвердити",
+  "cancel": "Скасувати",
+  "done": "Готово",
+  "failed": "Помилка",
+  "rankBadgeChasing": "Місце #{current} • +{delta} до #{target}",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "Статистика",
   "statsGamesSection": "Ігри",
   "statsGamesStarted": "Розпочаті ігри",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -17,6 +17,15 @@
       }
     }
   },
+  "toNextPlace": "距下一名还差 {points} 分",
+  "@toNextPlace": {
+    "placeholders": {
+      "points": {
+        "type": "int"
+      }
+    }
+  },
+  "youAreTop": "您是第 1 名",
   "championshipRoundDescriptionPlaceholder": "进行这一轮，推动你的锦标赛征程。",
   "championshipRoundCompletedLabel": "已完成",
   "totalScore": "总得分：{score}",
@@ -28,7 +37,7 @@
     }
   },
   "meLabel": "我",
-  "leaderboardRow": "第{rank}名，{name}，{points} 分",
+  "leaderboardRow": "第 {rank} 名。{name}。{points} 分",
   "@leaderboardRow": {
     "placeholders": {
       "rank": {
@@ -42,7 +51,7 @@
       }
     }
   },
-  "yourPosition": "我的排名第{rank}名，{points} 分",
+  "yourPosition": "我的名次 {rank}。{points} 分",
   "@yourPosition": {
     "placeholders": {
       "rank": {
@@ -55,6 +64,7 @@
   },
   "pointsShort": "分",
   "championshipAutoScroll": "自动滚动到我的位置",
+  "bestLabel": "最佳成绩",
   "play": "游玩",
   "battleTitle": "对战",
   "battleWinRate": "胜率 {percent}%",
@@ -168,6 +178,7 @@
   "vibrationLabel": "震动",
   "musicLabel": "背景音乐",
   "miscSectionTitle": "其他",
+  "championshipLocalSection": "锦标赛（本地）",
   "hideCompletedNumbersLabel": "隐藏已用数字",
   "aboutApp": "关于",
   "versionLabel": "版本 {version}",
@@ -186,6 +197,28 @@
   "languageFrench": "Français",
   "languageChinese": "中文",
   "languageHindi": "हिन्दी",
+  "export": "导出",
+  "import": "导入",
+  "resetMyScore": "重置我的得分",
+  "regenerateOpponents": "重新生成对手",
+  "confirm": "确认",
+  "cancel": "取消",
+  "done": "完成",
+  "failed": "失败",
+  "rankBadgeChasing": "第 {current} 名 • 还差 {delta} 分到第 {target} 名",
+  "@rankBadgeChasing": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "delta": {
+        "type": "int"
+      },
+      "target": {
+        "type": "int"
+      }
+    }
+  },
   "statsTitle": "统计",
   "statsGamesSection": "对局",
   "statsGamesStarted": "开始的对局",

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'championship/championship_model.dart';
+import 'championship/championship_backup.dart';
 import 'models.dart';
 import 'widgets/theme_menu.dart';
 
@@ -83,6 +86,29 @@ class SettingsPage extends StatelessWidget {
           ),
           const Divider(height: 32),
 
+          _sectionTitle(l10n.championshipLocalSection),
+          ListTile(
+            leading: const Icon(Icons.download_rounded),
+            title: Text(l10n.export),
+            onTap: () => _exportChampionship(context, championship),
+          ),
+          ListTile(
+            leading: const Icon(Icons.upload_rounded),
+            title: Text(l10n.import),
+            onTap: () => _importChampionship(context, championship),
+          ),
+          ListTile(
+            leading: const Icon(Icons.restart_alt_rounded),
+            title: Text(l10n.resetMyScore),
+            onTap: () => _resetChampionshipScore(context, championship),
+          ),
+          ListTile(
+            leading: const Icon(Icons.groups_rounded),
+            title: Text(l10n.regenerateOpponents),
+            onTap: () => _regenerateOpponents(context, championship),
+          ),
+          const Divider(height: 32),
+
           _sectionTitle(l10n.miscSectionTitle),
           ListTile(
             key: const ValueKey('settings-about'),
@@ -110,6 +136,154 @@ class SettingsPage extends StatelessWidget {
         text,
         style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
       ),
+    );
+  }
+
+  Future<void> _exportChampionship(
+    BuildContext context,
+    ChampionshipModel championship,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final snapshot = championship.createBackupData(DateTime.now());
+      await ChampionshipBackupManager.saveBackup(snapshot);
+      if (!context.mounted) return;
+      _showSnack(context, l10n.done);
+    } catch (_) {
+      if (!context.mounted) return;
+      _showSnack(context, l10n.failed);
+    }
+  }
+
+  Future<void> _importChampionship(
+    BuildContext context,
+    ChampionshipModel championship,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const ['json'],
+      );
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+      final filePath = result.files.single.path;
+      if (filePath == null) {
+        _showSnack(context, l10n.failed);
+        return;
+      }
+      final file = File(filePath);
+      final data = await ChampionshipBackupManager.loadFromFile(file);
+      if (!context.mounted) return;
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) {
+          return AlertDialog(
+            title: Text(l10n.import),
+            content: Text(l10n.confirm),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: Text(l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: Text(l10n.confirm),
+              ),
+            ],
+          );
+        },
+      );
+      if (confirmed != true) {
+        return;
+      }
+      await championship.restoreFromBackup(data);
+      if (!context.mounted) return;
+      _showSnack(context, l10n.done);
+    } catch (_) {
+      if (!context.mounted) return;
+      _showSnack(context, l10n.failed);
+    }
+  }
+
+  Future<void> _resetChampionshipScore(
+    BuildContext context,
+    ChampionshipModel championship,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(l10n.resetMyScore),
+          content: Text(l10n.confirm),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(l10n.cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(l10n.confirm),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) {
+      return;
+    }
+    try {
+      await championship.resetMyScore();
+      if (!context.mounted) return;
+      _showSnack(context, l10n.done);
+    } catch (_) {
+      if (!context.mounted) return;
+      _showSnack(context, l10n.failed);
+    }
+  }
+
+  Future<void> _regenerateOpponents(
+    BuildContext context,
+    ChampionshipModel championship,
+  ) async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(l10n.regenerateOpponents),
+          content: Text(l10n.confirm),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(l10n.cancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(l10n.confirm),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) {
+      return;
+    }
+    try {
+      await championship.regenerateOpponents();
+      if (!context.mounted) return;
+      _showSnack(context, l10n.done);
+    } catch (_) {
+      if (!context.mounted) return;
+      _showSnack(context, l10n.failed);
+    }
+  }
+
+  void _showSnack(BuildContext context, String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   provider: ^6.1.5+1
   shared_preferences: ^2.5.3
   intl: ^0.20.2
+  path_provider: ^2.1.4
+  file_picker: ^8.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- show per-rank progress with animated indicator and optimized leaderboard rendering on the Championship screen
- surface the current rank gap on the Home championship card and add localization coverage for the new copy
- add offline championship backup/import, reset, and opponent regeneration workflows plus harden the model against edge cases

## Testing
- `flutter analyze` *(fails: flutter tool not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5e38161c83268687ae445d49cb58