### PR TITLE
Fix Flutter build errors

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -471,7 +471,7 @@ class _ChallengeCardData {
 class _ChallengeCard extends StatelessWidget {
   final _ChallengeCardData data;
 
-  const _ChallengeCard({required this.data});
+  const _ChallengeCard({Key? key, required this.data}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -82,7 +82,7 @@ class SettingsPage extends StatelessWidget {
             title: Text(l10n.championshipAutoScroll),
             value: championship.autoScrollEnabled,
             onChanged: (v) => championship.setAutoScrollEnabled(v),
-            secondary: const Icon(Icons.my_location_alt),
+            secondary: const Icon(Icons.my_location),
           ),
           const Divider(height: 32),
 


### PR DESCRIPTION
## Summary
- import Flutter foundation types to allow using ValueListenable in the game header
- add key support to challenge cards so list items can supply ValueKeys
- replace unavailable icon with supported alternative in settings

## Testing
- Not run (Flutter/Dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd69b70f148326bdf164328de22cae