### PR TITLE
Add rank progress display to difficulty selector

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -996,13 +996,10 @@ class AppState extends ChangeNotifier {
         }
         stats.currentStreak++;
         stats.bestStreak = math.max(stats.bestStreak, stats.currentStreak);
-        stats.progressCurrent = math.min(
-          stats.progressTarget,
-          stats.progressCurrent + 1,
-        );
+        stats.progressCurrent += 1;
         if (stats.progressCurrent >= stats.progressTarget) {
           stats.level++;
-          stats.rank = math.max(1, stats.rank - 1);
+          stats.rank++;
           stats.progressCurrent = 0;
           stats.progressTarget += stats.level ~/ 2 + 5;
           heartBonus = 1;


### PR DESCRIPTION
## Summary
- replace the difficulty sheet rows with a layout that shows a progress bar and rank badge
- display the current win count over the target needed to advance for each difficulty
- adjust rank progression so victories increase the rank and reset the per-rank counter

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce609bd6fc83269308418b76a0407c