### PR TITLE
Simplify local championship settings

### DIFF
--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -236,6 +236,10 @@ abstract class AppLocalizations {
 
   String get resetMyScore;
 
+  String get resetMyScoreConfirmation;
+
+  String get resetAction;
+
   String get regenerateOpponents;
 
   String get confirm;
@@ -682,6 +686,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get resetMyScore => "Meinen Punktestand zurücksetzen";
 
   @override
+  String get resetMyScoreConfirmation =>
+      "Sind Sie sicher, dass Sie den Punktestand zurücksetzen möchten? Diese Aktion kann nicht rückgängig gemacht werden.";
+
+  @override
+  String get resetAction => "Zurücksetzen";
+
+  @override
   String get regenerateOpponents => "Gegner neu erstellen";
 
   @override
@@ -1109,6 +1120,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetMyScore => "Reset my score";
 
   @override
+  String get resetMyScoreConfirmation =>
+      "Are you sure you want to reset the score? This action cannot be undone.";
+
+  @override
+  String get resetAction => "Reset";
+
+  @override
   String get regenerateOpponents => "Regenerate opponents";
 
   @override
@@ -1518,6 +1536,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get resetMyScore => "Réinitialiser mon score";
+
+  @override
+  String get resetMyScoreConfirmation =>
+      "Voulez-vous vraiment réinitialiser le score ? Cette action est irréversible.";
+
+  @override
+  String get resetAction => "Réinitialiser";
 
   @override
   String get regenerateOpponents => "Régénérer les adversaires";
@@ -1937,6 +1962,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get resetMyScore => "मेरा स्कोर रीसेट करें";
+
+  @override
+  String get resetMyScoreConfirmation =>
+      "क्या आप वाकई स्कोर रीसेट करना चाहते हैं? यह कार्रवाई अपरिवर्तनीय है।";
+
+  @override
+  String get resetAction => "रीसेट करें";
 
   @override
   String get regenerateOpponents => "प्रतिद्वंद्वी पुनः उत्पन्न करें";
@@ -2362,6 +2394,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get resetMyScore => "Сбросить мой счёт";
 
   @override
+  String get resetMyScoreConfirmation =>
+      "Вы уверены, что хотите сбросить счёт? Это действие необратимо.";
+
+  @override
+  String get resetAction => "Сбросить";
+
+  @override
   String get regenerateOpponents => "Перегенерировать соперников";
 
   @override
@@ -2785,6 +2824,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get resetMyScore => "Скинути мій рахунок";
 
   @override
+  String get resetMyScoreConfirmation =>
+      "Ви впевнені, що хочете скинути рахунок? Цю дію неможливо скасувати.";
+
+  @override
+  String get resetAction => "Скинути";
+
+  @override
   String get regenerateOpponents => "Перегенерувати суперників";
 
   @override
@@ -3200,6 +3246,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get resetMyScore => "重置我的得分";
+
+  @override
+  String get resetMyScoreConfirmation => "确定要重置得分吗？此操作无法撤销。";
+
+  @override
+  String get resetAction => "重置";
 
   @override
   String get regenerateOpponents => "重新生成对手";

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -200,6 +200,8 @@
   "export": "Exportieren",
   "import": "Importieren",
   "resetMyScore": "Meinen Punktestand zurücksetzen",
+  "resetMyScoreConfirmation": "Sind Sie sicher, dass Sie den Punktestand zurücksetzen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+  "resetAction": "Zurücksetzen",
   "regenerateOpponents": "Gegner neu erstellen",
   "confirm": "Bestätigen",
   "cancel": "Abbrechen",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -200,6 +200,8 @@
   "export": "Export",
   "import": "Import",
   "resetMyScore": "Reset my score",
+  "resetMyScoreConfirmation": "Are you sure you want to reset the score? This action cannot be undone.",
+  "resetAction": "Reset",
   "regenerateOpponents": "Regenerate opponents",
   "confirm": "Confirm",
   "cancel": "Cancel",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -200,6 +200,8 @@
   "export": "Exporter",
   "import": "Importer",
   "resetMyScore": "Réinitialiser mon score",
+  "resetMyScoreConfirmation": "Voulez-vous vraiment réinitialiser le score ? Cette action est irréversible.",
+  "resetAction": "Réinitialiser",
   "regenerateOpponents": "Régénérer les adversaires",
   "confirm": "Confirmer",
   "cancel": "Annuler",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -200,6 +200,8 @@
   "export": "निर्यात",
   "import": "आयात",
   "resetMyScore": "मेरा स्कोर रीसेट करें",
+  "resetMyScoreConfirmation": "क्या आप वाकई स्कोर रीसेट करना चाहते हैं? यह कार्रवाई अपरिवर्तनीय है।",
+  "resetAction": "रीसेट करें",
   "regenerateOpponents": "प्रतिद्वंद्वी पुनः उत्पन्न करें",
   "confirm": "पुष्टि करें",
   "cancel": "रद्द करें",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -200,6 +200,8 @@
   "export": "Экспорт",
   "import": "Импорт",
   "resetMyScore": "Сбросить мой счёт",
+  "resetMyScoreConfirmation": "Вы уверены, что хотите сбросить счёт? Это действие необратимо.",
+  "resetAction": "Сбросить",
   "regenerateOpponents": "Перегенерировать соперников",
   "confirm": "Подтвердить",
   "cancel": "Отмена",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -200,6 +200,8 @@
   "export": "Експорт",
   "import": "Імпорт",
   "resetMyScore": "Скинути мій рахунок",
+  "resetMyScoreConfirmation": "Ви впевнені, що хочете скинути рахунок? Цю дію неможливо скасувати.",
+  "resetAction": "Скинути",
   "regenerateOpponents": "Перегенерувати суперників",
   "confirm": "Підтвердити",
   "cancel": "Скасувати",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -200,6 +200,8 @@
   "export": "导出",
   "import": "导入",
   "resetMyScore": "重置我的得分",
+  "resetMyScoreConfirmation": "确定要重置得分吗？此操作无法撤销。",
+  "resetAction": "重置",
   "regenerateOpponents": "重新生成对手",
   "confirm": "确认",
   "cancel": "取消",

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,13 +1,10 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'championship/championship_model.dart';
-import 'championship/championship_backup.dart';
 import 'models.dart';
 import 'widgets/theme_menu.dart';
 
@@ -88,24 +85,9 @@ class SettingsPage extends StatelessWidget {
 
           _sectionTitle(l10n.championshipLocalSection),
           ListTile(
-            leading: const Icon(Icons.download_rounded),
-            title: Text(l10n.export),
-            onTap: () => _exportChampionship(context, championship),
-          ),
-          ListTile(
-            leading: const Icon(Icons.upload_rounded),
-            title: Text(l10n.import),
-            onTap: () => _importChampionship(context, championship),
-          ),
-          ListTile(
             leading: const Icon(Icons.restart_alt_rounded),
             title: Text(l10n.resetMyScore),
             onTap: () => _resetChampionshipScore(context, championship),
-          ),
-          ListTile(
-            leading: const Icon(Icons.groups_rounded),
-            title: Text(l10n.regenerateOpponents),
-            onTap: () => _regenerateOpponents(context, championship),
           ),
           const Divider(height: 32),
 
@@ -139,74 +121,6 @@ class SettingsPage extends StatelessWidget {
     );
   }
 
-  Future<void> _exportChampionship(
-    BuildContext context,
-    ChampionshipModel championship,
-  ) async {
-    final l10n = AppLocalizations.of(context)!;
-    try {
-      final snapshot = championship.createBackupData(DateTime.now());
-      await ChampionshipBackupManager.saveBackup(snapshot);
-      if (!context.mounted) return;
-      _showSnack(context, l10n.done);
-    } catch (_) {
-      if (!context.mounted) return;
-      _showSnack(context, l10n.failed);
-    }
-  }
-
-  Future<void> _importChampionship(
-    BuildContext context,
-    ChampionshipModel championship,
-  ) async {
-    final l10n = AppLocalizations.of(context)!;
-    try {
-      final result = await FilePicker.platform.pickFiles(
-        type: FileType.custom,
-        allowedExtensions: const ['json'],
-      );
-      if (result == null || result.files.isEmpty) {
-        return;
-      }
-      final filePath = result.files.single.path;
-      if (filePath == null) {
-        _showSnack(context, l10n.failed);
-        return;
-      }
-      final file = File(filePath);
-      final data = await ChampionshipBackupManager.loadFromFile(file);
-      if (!context.mounted) return;
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (dialogContext) {
-          return AlertDialog(
-            title: Text(l10n.import),
-            content: Text(l10n.confirm),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(false),
-                child: Text(l10n.cancel),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(true),
-                child: Text(l10n.confirm),
-              ),
-            ],
-          );
-        },
-      );
-      if (confirmed != true) {
-        return;
-      }
-      await championship.restoreFromBackup(data);
-      if (!context.mounted) return;
-      _showSnack(context, l10n.done);
-    } catch (_) {
-      if (!context.mounted) return;
-      _showSnack(context, l10n.failed);
-    }
-  }
-
   Future<void> _resetChampionshipScore(
     BuildContext context,
     ChampionshipModel championship,
@@ -217,15 +131,19 @@ class SettingsPage extends StatelessWidget {
       builder: (dialogContext) {
         return AlertDialog(
           title: Text(l10n.resetMyScore),
-          content: Text(l10n.confirm),
+          content: Text(l10n.resetMyScoreConfirmation),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(dialogContext).pop(false),
               child: Text(l10n.cancel),
             ),
             TextButton(
+              style: TextButton.styleFrom(
+                foregroundColor:
+                    Theme.of(dialogContext).colorScheme.error,
+              ),
               onPressed: () => Navigator.of(dialogContext).pop(true),
-              child: Text(l10n.confirm),
+              child: Text(l10n.resetAction),
             ),
           ],
         );
@@ -236,43 +154,6 @@ class SettingsPage extends StatelessWidget {
     }
     try {
       await championship.resetMyScore();
-      if (!context.mounted) return;
-      _showSnack(context, l10n.done);
-    } catch (_) {
-      if (!context.mounted) return;
-      _showSnack(context, l10n.failed);
-    }
-  }
-
-  Future<void> _regenerateOpponents(
-    BuildContext context,
-    ChampionshipModel championship,
-  ) async {
-    final l10n = AppLocalizations.of(context)!;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) {
-        return AlertDialog(
-          title: Text(l10n.regenerateOpponents),
-          content: Text(l10n.confirm),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(dialogContext).pop(false),
-              child: Text(l10n.cancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(dialogContext).pop(true),
-              child: Text(l10n.confirm),
-            ),
-          ],
-        );
-      },
-    );
-    if (confirmed != true) {
-      return;
-    }
-    try {
-      await championship.regenerateOpponents();
       if (!context.mounted) return;
       _showSnack(context, l10n.done);
     } catch (_) {


### PR DESCRIPTION
## Summary
- remove local championship import, export, and opponent regeneration entries from settings
- add a confirmation dialog with a danger-styled reset action for clearing the local championship score
- localize the new confirmation message and reset action label across supported languages

## Testing
- Not run (Flutter SDK is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68ce699d00048326be45dc54e5228cef