### PR TITLE
Refactor language selection into dedicated page

### DIFF
--- a/lib/language_settings_page.dart
+++ b/lib/language_settings_page.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'models.dart';
+
+class LanguageSettingsPage extends StatelessWidget {
+  const LanguageSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final app = context.watch<AppState>();
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.languageSectionTitle),
+        centerTitle: true,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          ...AppLanguage.values.map(
+            (lang) => RadioListTile<AppLanguage>(
+              key: ValueKey('lang-${lang.name}'),
+              title: Text(lang.displayName(l10n)),
+              value: lang,
+              groupValue: app.lang,
+              onChanged: (value) {
+                if (value != null) {
+                  unawaited(app.setLang(value));
+                }
+              },
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'championship/championship_model.dart';
+import 'language_settings_page.dart';
 import 'models.dart';
 import 'widgets/theme_menu.dart';
 
@@ -37,18 +38,25 @@ class SettingsPage extends StatelessWidget {
           const Divider(height: 32),
 
           _sectionTitle(l10n.languageSectionTitle),
-          ...AppLanguage.values.map(
-                (lang) => RadioListTile<AppLanguage>(
-              key: ValueKey('lang-${lang.name}'),
-              title: Text(lang.displayName(l10n)),
-              value: lang,
-              groupValue: app.lang,
-              onChanged: (v) {
-                if (v != null) {
-                  unawaited(app.setLang(v));
-                }
-              },
+          ListTile(
+            key: const ValueKey('settings-language'),
+            leading: const Icon(Icons.language_outlined),
+            title: Text(l10n.languageSectionTitle),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(app.lang.displayName(l10n)),
+                const SizedBox(width: 8),
+                const Icon(Icons.chevron_right),
+              ],
             ),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const LanguageSettingsPage(),
+                ),
+              );
+            },
           ),
           const Divider(height: 32),
 


### PR DESCRIPTION
## Summary
- replace the inline language radio list on the settings screen with a single Language row that shows the active locale
- add a dedicated Language settings page that mirrors the previous radio selection UI

## Testing
- flutter test *(fails: flutter command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce74583bb88326899f48cbd5942081