### PR TITLE
Update difficulty selection UI

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -32,6 +32,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Судоку Майстер'), findsOneWidget);
-    expect(find.text('Щоденний виклик'), findsWidgets);
+    expect(find.text('Нова гра'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- remove the daily challenge option from the difficulty sheet and return the chosen difficulty directly
- restyle difficulty tiles with reduced height, theme-based colors, and an animated progress bar that reflects solved/total stats
- update the widget test to match the new home screen copy

## Testing
- flutter test *(fails: `flutter` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cee76381808326a8f4dfdbb9619370