### PR TITLE
Add intro video screen before home

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'championship/championship_model.dart';
 import 'championship/championship_page.dart';
 import 'home_screen.dart';
 import 'models.dart';
+import 'screens/intro_screen.dart';
 import 'theme.dart';
 import 'undo_ad_controller.dart';
 
@@ -73,10 +74,12 @@ class SudokuApp extends StatelessWidget {
           child: child ?? const SizedBox.shrink(),
         );
       },
+      initialRoute: '/intro',
       routes: {
+        '/intro': (context) => const IntroScreen(),
+        '/home': (context) => const HomeScreen(),
         '/championship': (context) => const ChampionshipPage(),
       },
-      home: const HomeScreen(),
     );
   }
 }

--- a/lib/screens/intro_screen.dart
+++ b/lib/screens/intro_screen.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class IntroScreen extends StatefulWidget {
+  const IntroScreen({super.key});
+
+  @override
+  State<IntroScreen> createState() => _IntroScreenState();
+}
+
+class _IntroScreenState extends State<IntroScreen> {
+  late final VideoPlayerController _controller;
+  Timer? _navigationTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.asset('assets/videos/intro.mp4')
+      ..setLooping(false);
+    _initializeVideo();
+  }
+
+  Future<void> _initializeVideo() async {
+    await _controller.initialize();
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+    await _controller.play();
+    _navigationTimer = Timer(const Duration(seconds: 5), _navigateToHome);
+  }
+
+  void _navigateToHome() {
+    if (!mounted) {
+      return;
+    }
+    Navigator.pushReplacementNamed(context, '/home');
+  }
+
+  @override
+  void dispose() {
+    _navigationTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Center(
+        child: _controller.value.isInitialized
+            ? SizedBox.expand(
+                child: FittedBox(
+                  fit: BoxFit.cover,
+                  child: SizedBox(
+                    width: _controller.value.size.width,
+                    height: _controller.value.size.height,
+                    child: VideoPlayer(_controller),
+                  ),
+                ),
+              )
+            : const CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   intl: ^0.20.2
   path_provider: ^2.1.4
   file_picker: ^8.1.2
+  video_player: ^2.9.2
 
 dev_dependencies:
   flutter_test:
@@ -67,6 +68,7 @@ flutter:
 
   assets:
     - assets/data/names.json
+    - assets/videos/intro.mp4
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- add the intro video asset and `video_player` plugin dependency
- implement an `IntroScreen` that plays the intro video and navigates to the home screen after 5 seconds
- update the app routes to launch the new intro screen before the existing home screen

## Testing
- `flutter pub get` *(fails: `flutter` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf17c5388883269978a65a2c434040