### PR TITLE
Replace completed daily challenge numbers with a star icon

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1737,13 +1737,27 @@ class _CalendarDayButton extends StatelessWidget {
       fontWeight: FontWeight.w700,
       color: textColor,
     );
-    final indicatorColor = selected ? cs.onPrimary : cs.secondary;
     final border = today
         ? Border.all(
             color: selected ? cs.onPrimary : cs.primary,
             width: 3,
           )
         : null;
+    final Widget dayContent;
+    if (completed) {
+      dayContent = const Icon(
+        Icons.star_rounded,
+        color: Color(0xFFFFD700),
+        size: 26,
+      );
+    } else {
+      dayContent = Text(
+        '${date.day}',
+        style: textStyle,
+        textAlign: TextAlign.center,
+        softWrap: false,
+      );
+    }
 
     return AnimatedScale(
       duration: const Duration(milliseconds: 200),
@@ -1762,29 +1776,7 @@ class _CalendarDayButton extends StatelessWidget {
           child: InkWell(
             customBorder: const CircleBorder(),
             onTap: locked ? null : onTap,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  '${date.day}',
-                  style: textStyle,
-                  textAlign: TextAlign.center,
-                  softWrap: false,
-                ),
-                if (completed)
-                  Padding(
-                    padding: const EdgeInsets.only(top: 6),
-                    child: Container(
-                      width: 8,
-                      height: 8,
-                      decoration: BoxDecoration(
-                        color: indicatorColor,
-                        shape: BoxShape.circle,
-                      ),
-                    ),
-                  ),
-              ],
-            ),
+            child: Center(child: dayContent),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- show a golden star icon on calendar days that have their daily challenge completed
- remove the secondary completion dot so the star fully replaces the day number

## Testing
- flutter analyze (fails: Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfc55f4fd48326830f90d45c3f2169