### PR TITLE
Replace coin indicators in daily challenge tab

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1515,7 +1515,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               const Icon(
-                                Icons.monetization_on_rounded,
+                                Icons.star_rounded,
                                 color: Color(0xFFFFD54F),
                                 size: 24,
                               ),
@@ -1574,26 +1574,9 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
                               ),
                               Expanded(
                                 child: Center(
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Text(
-                                        monthLabel,
-                                        style: monthHeaderStyle,
-                                      ),
-                                      const SizedBox(width: 8),
-                                      const Icon(
-                                        Icons.monetization_on_rounded,
-                                        color: Color(0xFFFFD54F),
-                                        size: 24,
-                                      ),
-                                      const SizedBox(width: 6),
-                                      Text(
-                                        '$progress/$monthDays',
-                                        style: monthHeaderStyle,
-                                      ),
-                                    ],
+                                  child: Text(
+                                    monthLabel,
+                                    style: monthHeaderStyle,
                                   ),
                                 ),
                               ),


### PR DESCRIPTION
## Summary
- replace the coin icon beneath the daily challenge heading with a star
- remove the coin progress indicator from the monthly calendar header

## Testing
- `flutter test` *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfcae1f04883268c7623fc8a1c0271