### PR TITLE
Soften dark theme challenge banners

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -495,17 +495,17 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
       numberPadRemainingHighlight: Color(0xFF3D82FF),
       shadowColor: Color(0x66000000),
       dailyChallengeGradient: const LinearGradient(
-        colors: [Color(0xFFFFF0B3), Color(0xFFFFC26F)],
+        colors: [Color(0xFF2A2514), Color(0xFF8C7536)],
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),
       championshipChallengeGradient: const LinearGradient(
-        colors: [Color(0xFFFFB2D0), Color(0xFFE55D87)],
+        colors: [Color(0xFF2B1322), Color(0xFF8A3159)],
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),
       battleChallengeGradient: const LinearGradient(
-        colors: [Color(0xFFCDE7FF), Color(0xFF3B82F6)],
+        colors: [Color(0xFF0D1F28), Color(0xFF2C6477)],
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
       ),


### PR DESCRIPTION
## Summary
- update the dark theme challenge banners to use muted yellow, magenta, and teal gradients so they blend with the night palette while remaining distinct
- keep the existing bright gradients for the light themes so their appearance is unchanged

## Testing
- Not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfd74d68148326b83fefb69ca8996b