### PR TITLE
Adjust daily calendar spacing

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1636,7 +1636,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
         final horizontalPadding = lerpWidth(13.0, 28.0);
         final headerTopPadding = media.padding.top + lerpHeight(6.0, 36.0);
         final headerBottomPadding = lerpHeight(24.0, 132.0);
-        final headerOverlap = lerpHeight(56.0, 88.0);
+        final headerOverlap = lerpHeight(44.0, 76.0);
         final trophyDiameter = lerpHeight(54.0, 116.0);
         final trophyIconSize = lerpHeight(32.0, 64.0);
         final headerTrophySpacing = lerpHeight(4.0, 22.0);


### PR DESCRIPTION
## Summary
- lower the daily challenge calendar by decreasing the amount it overlaps the header

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d03cfa1e90832692351ed7d1c50faa