### PR TITLE
Adjust home banners spacing

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -122,6 +123,11 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
       titlePlaceholderHeight += textPainter.height;
     }
 
+    final dailyContentTopSpacing = math.max(
+      8.0,
+      titlePlaceholderHeight - (isCompactHeight ? 12.0 : 16.0),
+    );
+
     return SingleChildScrollView(
       padding: EdgeInsets.symmetric(vertical: verticalPadding),
       child: Column(
@@ -154,7 +160,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SizedBox(height: titlePlaceholderHeight),
+                SizedBox(height: dailyContentTopSpacing),
                 _DailyChain(streak: app.dailyStreak),
                 SizedBox(height: bodySpacing),
                 _ProgressCard(


### PR DESCRIPTION
## Summary
- reduce the placeholder spacing above the daily streak and progress cards to raise them on the home screen
- keep the rest of the home challenge banners untouched while maintaining a minimum gap for the raised banners

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0434494308326b5700edbfd55d22c