### PR TITLE
Align Sudoku board width with controls

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -852,7 +852,7 @@ double _estimateStatusBarHeight({
 }
 
 double _calculateBoardExtent(double width, double scale) {
-  final baseWidth = math.max(0.0, width - 40);
+  final baseWidth = math.max(0.0, width - 24);
   return math.min(width, baseWidth * scale);
 }
 


### PR DESCRIPTION
## Summary
- update the board width calculation so the Sudoku grid shares the same horizontal padding as the control panel

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d06b0e3b0c8326a48e715bdeb6e85d