### PR TITLE
Fix cream theme preview appearance

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -650,8 +650,22 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
 
 /// Цвет, который используется для предпросмотра темы в меню выбора.
 Color themePreviewColor(SudokuTheme theme) {
-  if (theme == SudokuTheme.black) {
-    return const Color(0xFF000000);
+  switch (theme) {
+    case SudokuTheme.black:
+      return const Color(0xFF000000);
+    case SudokuTheme.cream:
+      return const Color(0xFFFFF5E1);
+    default:
+      return _themeConfigs[theme]!.primary;
   }
-  return _themeConfigs[theme]!.primary;
+}
+
+Border? themePreviewInnerBorder(SudokuTheme theme) {
+  if (theme == SudokuTheme.cream) {
+    return Border.all(
+      color: const Color(0xFFBEBEBE),
+      width: 1,
+    );
+  }
+  return null;
 }

--- a/lib/widgets/theme_menu.dart
+++ b/lib/widgets/theme_menu.dart
@@ -123,6 +123,7 @@ class _ThemeCircle extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final baseColor = themePreviewColor(option);
+    final innerBorder = themePreviewInnerBorder(option);
     final borderColor = active ? cs.primary : cs.outlineVariant;
 
     return GestureDetector(
@@ -148,6 +149,7 @@ class _ThemeCircle extends StatelessWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: baseColor,
+                border: innerBorder,
               ),
             ),
             if (active)


### PR DESCRIPTION
## Summary
- use a dedicated cream color for the cream theme preview instead of the green primary shade
- add a subtle inner border to the cream preview circle so it stays visible against light backgrounds

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d070fdb7bc8326922a6e12e34c69bd