### PR TITLE
Fix battle timer imports and share elapsed state extension

### DIFF
--- a/lib/battle/battle_page.dart
+++ b/lib/battle/battle_page.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';

--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -15,8 +15,6 @@ import 'widgets/board.dart';
 import 'widgets/control_panel.dart';
 import 'widgets/theme_menu.dart';
 
-final _elapsedMsExpando = Expando<int>('elapsedMs');
-
 const int _kInitialHints = 3;
 const int _kInitialLives = 3;
 const double _kGameplayUiScale = 1.1;
@@ -28,12 +26,6 @@ const double _kGameContentBottomPadding = 40.0;
 const double _kBoardToControlsSpacing = 8.0;
 const double _kCompactHeightBreakpoint = 720.0;
 const double _kTextHeightMultiplier = 1.1;
-
-extension _GameStateElapsedMs on GameState {
-  int get elapsedMs => _elapsedMsExpando[this] ?? 0;
-
-  set elapsedMs(int value) => _elapsedMsExpando[this] = value;
-}
 
 class GamePage extends StatefulWidget {
   const GamePage({super.key});

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -131,6 +131,14 @@ class GameState {
   });
 }
 
+final _elapsedMsExpando = Expando<int>('elapsedMs');
+
+extension GameStateElapsedMs on GameState {
+  int get elapsedMs => _elapsedMsExpando[this] ?? 0;
+
+  set elapsedMs(int value) => _elapsedMsExpando[this] = value;
+}
+
 /// Хранит статистику для конкретного уровня сложности.
 class DifficultyStats {
   int gamesStarted;


### PR DESCRIPTION
## Summary
- add the scheduler and foundation imports needed by the battle page ticker logic
- move the `GameState` elapsed time extension into `models.dart` so multiple screens can share it

## Testing
- flutter analyze *(fails: `flutter` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07db1b4588326b9ac427f48eafb25