### PR TITLE
Remove outer border from Sudoku board

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -22,7 +22,6 @@ class Board extends StatelessWidget {
     final outerRadius = BorderRadius.circular(_boardOuterRadiusValue * scale);
     final innerRadius = BorderRadius.circular(_boardInnerRadiusValue * scale);
     final outerPadding = 16.0 * scale;
-    final borderWidth = 4.0 * scale;
     final shadowBlur = 24.0 * scale;
     final shadowOffset = Offset(0, 16 * scale);
 
@@ -48,7 +47,6 @@ class Board extends StatelessWidget {
         final innerDecoration = BoxDecoration(
           color: colors.boardInner,
           borderRadius: innerRadius,
-          border: Border.all(color: colors.boardBorder, width: borderWidth),
         );
 
         return RepaintBoundary(


### PR DESCRIPTION
## Summary
- remove the decorative border around the Sudoku board so the grid extends to the container edges

## Testing
- flutter analyze *(fails: Flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1297160788326b064e1abc35e81ca