### PR TITLE
Slightly enlarge sudoku board

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -7,7 +7,7 @@ import '../theme.dart';
 
 const double _boardOuterRadiusValue = 28;
 const double _boardInnerRadiusValue = 12;
-const double _boardOuterPaddingValue = 12;
+const double _boardOuterPaddingValue = 10;
 
 class Board extends StatelessWidget {
   final double scale;


### PR DESCRIPTION
## Summary
- reduce the board's outer padding so the Sudoku grid renders slightly larger without touching other UI scaling

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d134e86a388326b58aa7853d7e1613