### PR TITLE
Improve battle mode flag flow and HUD

### DIFF
--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -112,6 +112,10 @@ abstract class AppLocalizations {
 
   String get selectPlayerFlag;
 
+  String get confirmFlagSelectionTitle;
+
+  String get confirmFlagSelectionMessage;
+
   String get startAction;
 
   String levelHeading(int level, String difficulty);
@@ -509,6 +513,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "Wähle deine Flagge";
+
+  @override
+  String get confirmFlagSelectionTitle => "Bestätige deine Flagge";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Du kannst deine Flagge später in den Spieleinstellungen ändern.";
 
   @override
   String get startAction => "Starten";
@@ -968,6 +979,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get selectPlayerFlag => "Choose your flag";
 
   @override
+  String get confirmFlagSelectionTitle => "Confirm your flag";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "You can change your flag later in the game settings.";
+
+  @override
   String get startAction => "Start";
 
   @override
@@ -1423,6 +1441,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "Elige tu bandera";
+
+  @override
+  String get confirmFlagSelectionTitle => "Confirma tu bandera";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Podrás cambiar tu bandera más adelante en los ajustes del juego.";
 
   @override
   String get startAction => "Comenzar";
@@ -1882,6 +1907,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get selectPlayerFlag => "Choisis ton drapeau";
 
   @override
+  String get confirmFlagSelectionTitle => "Confirme ton drapeau";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.";
+
+  @override
   String get startAction => "Commencer";
 
   @override
@@ -2337,6 +2369,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "अपना झंडा चुनें";
+
+  @override
+  String get confirmFlagSelectionTitle => "अपने झंडे की पुष्टि करें";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।";
 
   @override
   String get startAction => "शुरू करें";
@@ -2796,6 +2835,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get selectPlayerFlag => "Scegli la tua bandiera";
 
   @override
+  String get confirmFlagSelectionTitle => "Conferma la tua bandiera";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.";
+
+  @override
   String get startAction => "Inizio";
 
   @override
@@ -3251,6 +3297,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "自分の旗を選択";
+
+  @override
+  String get confirmFlagSelectionTitle => "フラグを確認";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "フラグは後でゲーム設定で変更できます。";
 
   @override
   String get startAction => "始める";
@@ -3710,6 +3763,13 @@ class AppLocalizationsKa extends AppLocalizations {
   String get selectPlayerFlag => "აირჩიე შენი დროშა";
 
   @override
+  String get confirmFlagSelectionTitle => "დაადასტურე შენი დროშა";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.";
+
+  @override
   String get startAction => "დაწყება";
 
   @override
@@ -4167,6 +4227,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get selectPlayerFlag => "깃발을 선택하세요";
 
   @override
+  String get confirmFlagSelectionTitle => "깃발 확인";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "나중에 게임 설정에서 깃발을 변경할 수 있습니다.";
+
+  @override
   String get startAction => "시작";
 
   @override
@@ -4622,6 +4689,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "Выбери свой флаг";
+
+  @override
+  String get confirmFlagSelectionTitle => "Подтвердите флаг";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Вы сможете сменить флаг позже в настройках игры.";
 
   @override
   String get startAction => "Начать";
@@ -5085,6 +5159,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get selectPlayerFlag => "Обери свій прапор";
 
   @override
+  String get confirmFlagSelectionTitle => "Підтвердь свій прапор";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "Ти зможеш змінити прапор пізніше в налаштуваннях гри.";
+
+  @override
   String get startAction => "Почати";
 
   @override
@@ -5544,6 +5625,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get selectPlayerFlag => "选择你的旗帜";
+
+  @override
+  String get confirmFlagSelectionTitle => "确认你的旗帜";
+
+  @override
+  String get confirmFlagSelectionMessage =>
+      "你可以稍后在游戏设置中更改你的旗帜。";
 
   @override
   String get startAction => "开始";

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Spielerflagge",
   "selectPlayerFlag": "Wähle deine Flagge",
+  "confirmFlagSelectionTitle": "Bestätige deine Flagge",
+  "confirmFlagSelectionMessage": "Du kannst deine Flagge später in den Spieleinstellungen ändern.",
   "startAction": "Starten",
   "levelHeading": "Level {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Player flag",
   "selectPlayerFlag": "Choose your flag",
+  "confirmFlagSelectionTitle": "Confirm your flag",
+  "confirmFlagSelectionMessage": "You can change your flag later in the game settings.",
   "startAction": "Start",
   "levelHeading": "Level {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Bandera del jugador",
   "selectPlayerFlag": "Elige tu bandera",
+  "confirmFlagSelectionTitle": "Confirma tu bandera",
+  "confirmFlagSelectionMessage": "Podrás cambiar tu bandera más adelante en los ajustes del juego.",
   "startAction": "Comenzar",
   "levelHeading": "Nivel {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Drapeau du joueur",
   "selectPlayerFlag": "Choisis ton drapeau",
+  "confirmFlagSelectionTitle": "Confirme ton drapeau",
+  "confirmFlagSelectionMessage": "Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.",
   "startAction": "Commencer",
   "levelHeading": "Niveau {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "खिलाड़ी का झंडा",
   "selectPlayerFlag": "अपना झंडा चुनें",
+  "confirmFlagSelectionTitle": "अपने झंडे की पुष्टि करें",
+  "confirmFlagSelectionMessage": "आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।",
   "startAction": "शुरू करें",
   "levelHeading": "स्तर {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Bandiera del giocatore",
   "selectPlayerFlag": "Scegli la tua bandiera",
+  "confirmFlagSelectionTitle": "Conferma la tua bandiera",
+  "confirmFlagSelectionMessage": "Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.",
   "startAction": "Inizio",
   "levelHeading": "Livello {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "プレイヤーの旗",
   "selectPlayerFlag": "自分の旗を選択",
+  "confirmFlagSelectionTitle": "フラグを確認",
+  "confirmFlagSelectionMessage": "フラグは後でゲーム設定で変更できます。",
   "startAction": "始める",
   "levelHeading": "レベル {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "მოთამაშის დროშა",
   "selectPlayerFlag": "აირჩიე შენი დროშა",
+  "confirmFlagSelectionTitle": "დაადასტურე შენი დროშა",
+  "confirmFlagSelectionMessage": "შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.",
   "startAction": "დაწყება",
   "levelHeading": "დონე {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "플레이어 깃발",
   "selectPlayerFlag": "깃발을 선택하세요",
+  "confirmFlagSelectionTitle": "깃발 확인",
+  "confirmFlagSelectionMessage": "나중에 게임 설정에서 깃발을 변경할 수 있습니다.",
   "startAction": "시작",
   "levelHeading": "레벨 {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Флаг игрока",
   "selectPlayerFlag": "Выбери свой флаг",
+  "confirmFlagSelectionTitle": "Подтвердите флаг",
+  "confirmFlagSelectionMessage": "Вы сможете сменить флаг позже в настройках игры.",
   "startAction": "Начать",
   "levelHeading": "Уровень {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "Прапор гравця",
   "selectPlayerFlag": "Обери свій прапор",
+  "confirmFlagSelectionTitle": "Підтвердь свій прапор",
+  "confirmFlagSelectionMessage": "Ти зможеш змінити прапор пізніше в налаштуваннях гри.",
   "startAction": "Почати",
   "levelHeading": "Рівень {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -88,6 +88,8 @@
   },
   "playerFlagSettingTitle": "玩家旗帜",
   "selectPlayerFlag": "选择你的旗帜",
+  "confirmFlagSelectionTitle": "确认你的旗帜",
+  "confirmFlagSelectionMessage": "你可以稍后在游戏设置中更改你的旗帜。",
   "startAction": "开始",
   "levelHeading": "等级 {level} — {difficulty}",
   "@levelHeading": {


### PR DESCRIPTION
## Summary
- prompt new battle players to confirm their flag choice and explain it can be changed later
- add a lives indicator and theme/settings buttons styled to match the classic game in battle mode
- localize the new confirmation strings across all supported languages

## Testing
- flutter test *(fails: flutter command is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13986b61c8326bda800da31af75c0