### PR TITLE
Fix battle background styling

### DIFF
--- a/lib/battle/battle_page.dart
+++ b/lib/battle/battle_page.dart
@@ -529,10 +529,15 @@ class _BattlePageState extends State<BattlePage>
 
     final media = MediaQuery.of(context);
     final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
 
     return Scaffold(
+      backgroundColor: scheme.background,
       appBar: AppBar(
         title: Text(l10n.battleTitle),
+        backgroundColor: scheme.background,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
         actions: [
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
@@ -598,6 +603,7 @@ class _BattlePageState extends State<BattlePage>
                 padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
                 child: Column(
                   children: [
+                    SizedBox(height: _kStatusBarOuterPadding * scale),
                     _BattleHeader(
                       elapsed: _elapsedVN,
                       playerName: l10n.battleYouLabel,


### PR DESCRIPTION
## Summary
- ensure the battle screen scaffold and app bar use the theme background color
- add top spacing before the battle banner so it reads as a separate card

## Testing
- flutter analyze *(fails: flutter command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14fffef08832695ddd6410029969f