### PR TITLE
Add flag selection confirmation prompt

### DIFF
--- a/lib/battle/battle_page.dart
+++ b/lib/battle/battle_page.dart
@@ -178,7 +178,7 @@ class _BattlePageState extends State<BattlePage>
                     Expanded(
                       child: ElevatedButton(
                         onPressed: () => Navigator.pop(context, true),
-                        child: Text(l10n.confirm),
+                        child: Text(l10n.confirmFlagSelectionConfirm),
                       ),
                     ),
                   ],

--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -116,6 +116,8 @@ abstract class AppLocalizations {
 
   String get confirmFlagSelectionMessage;
 
+  String get confirmFlagSelectionConfirm;
+
   String get startAction;
 
   String levelHeading(int level, String difficulty);
@@ -519,7 +521,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Du kannst deine Flagge später in den Spieleinstellungen ändern.";
+      "Bist du sicher, dass du diese Flagge auswählen möchtest? Du kannst deine Flagge später in den Spieleinstellungen ändern.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Bestätigen";
 
   @override
   String get startAction => "Starten";
@@ -983,7 +988,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "You can change your flag later in the game settings.";
+      "Are you sure you want to choose this flag? You can change your flag later in the game settings.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Confirm";
 
   @override
   String get startAction => "Start";
@@ -1447,7 +1455,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Podrás cambiar tu bandera más adelante en los ajustes del juego.";
+      "¿Estás seguro de que quieres elegir esta bandera? Podrás cambiar tu bandera más adelante en los ajustes del juego.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Confirmar";
 
   @override
   String get startAction => "Comenzar";
@@ -1911,7 +1922,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.";
+      "Es-tu sûr de vouloir choisir ce drapeau ? Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Confirmer";
 
   @override
   String get startAction => "Commencer";
@@ -2375,7 +2389,10 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।";
+      "क्या आप सुनिश्चित हैं कि आप इस झंडे को चुनना चाहते हैं? आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।";
+
+  @override
+  String get confirmFlagSelectionConfirm => "पुष्टि करें";
 
   @override
   String get startAction => "शुरू करें";
@@ -2839,7 +2856,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.";
+      "Sei sicuro di voler scegliere questa bandiera? Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Conferma";
 
   @override
   String get startAction => "Inizio";
@@ -3303,7 +3323,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "フラグは後でゲーム設定で変更できます。";
+      "この旗を選択してもよろしいですか？後でゲーム設定で旗を変更できます。";
+
+  @override
+  String get confirmFlagSelectionConfirm => "確認する";
 
   @override
   String get startAction => "始める";
@@ -3767,7 +3790,10 @@ class AppLocalizationsKa extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.";
+      "დარწმუნებული ხარ, რომ ამ დროშას ირჩევ? შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "დადასტურება";
 
   @override
   String get startAction => "დაწყება";
@@ -4231,7 +4257,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "나중에 게임 설정에서 깃발을 변경할 수 있습니다.";
+      "이 깃발을 선택하시겠습니까? 나중에 게임 설정에서 깃발을 변경할 수 있습니다.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "확인";
 
   @override
   String get startAction => "시작";
@@ -4695,7 +4724,10 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Вы сможете сменить флаг позже в настройках игры.";
+      "Вы уверены, что хотите выбрать этот флаг? Флаг можно будет изменить в настройках игры.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Подтверждаю";
 
   @override
   String get startAction => "Начать";
@@ -5163,7 +5195,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "Ти зможеш змінити прапор пізніше в налаштуваннях гри.";
+      "Ти впевнений, що хочеш обрати цей прапор? Ти зможеш змінити прапор пізніше в налаштуваннях гри.";
+
+  @override
+  String get confirmFlagSelectionConfirm => "Підтверджую";
 
   @override
   String get startAction => "Почати";
@@ -5631,7 +5666,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get confirmFlagSelectionMessage =>
-      "你可以稍后在游戏设置中更改你的旗帜。";
+      "你确定要选择这面旗帜吗？你可以稍后在游戏设置中更改你的旗帜。";
+
+  @override
+  String get confirmFlagSelectionConfirm => "确认";
 
   @override
   String get startAction => "开始";

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Spielerflagge",
   "selectPlayerFlag": "Wähle deine Flagge",
   "confirmFlagSelectionTitle": "Bestätige deine Flagge",
-  "confirmFlagSelectionMessage": "Du kannst deine Flagge später in den Spieleinstellungen ändern.",
+  "confirmFlagSelectionMessage": "Bist du sicher, dass du diese Flagge auswählen möchtest? Du kannst deine Flagge später in den Spieleinstellungen ändern.",
+  "confirmFlagSelectionConfirm": "Bestätigen",
   "startAction": "Starten",
   "levelHeading": "Level {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Player flag",
   "selectPlayerFlag": "Choose your flag",
   "confirmFlagSelectionTitle": "Confirm your flag",
-  "confirmFlagSelectionMessage": "You can change your flag later in the game settings.",
+  "confirmFlagSelectionMessage": "Are you sure you want to choose this flag? You can change your flag later in the game settings.",
+  "confirmFlagSelectionConfirm": "Confirm",
   "startAction": "Start",
   "levelHeading": "Level {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Bandera del jugador",
   "selectPlayerFlag": "Elige tu bandera",
   "confirmFlagSelectionTitle": "Confirma tu bandera",
-  "confirmFlagSelectionMessage": "Podrás cambiar tu bandera más adelante en los ajustes del juego.",
+  "confirmFlagSelectionMessage": "¿Estás seguro de que quieres elegir esta bandera? Podrás cambiar tu bandera más adelante en los ajustes del juego.",
+  "confirmFlagSelectionConfirm": "Confirmar",
   "startAction": "Comenzar",
   "levelHeading": "Nivel {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Drapeau du joueur",
   "selectPlayerFlag": "Choisis ton drapeau",
   "confirmFlagSelectionTitle": "Confirme ton drapeau",
-  "confirmFlagSelectionMessage": "Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.",
+  "confirmFlagSelectionMessage": "Es-tu sûr de vouloir choisir ce drapeau ? Tu pourras changer ton drapeau plus tard dans les paramètres du jeu.",
+  "confirmFlagSelectionConfirm": "Confirmer",
   "startAction": "Commencer",
   "levelHeading": "Niveau {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "खिलाड़ी का झंडा",
   "selectPlayerFlag": "अपना झंडा चुनें",
   "confirmFlagSelectionTitle": "अपने झंडे की पुष्टि करें",
-  "confirmFlagSelectionMessage": "आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।",
+  "confirmFlagSelectionMessage": "क्या आप सुनिश्चित हैं कि आप इस झंडे को चुनना चाहते हैं? आप बाद में खेल की सेटिंग्स में अपना झंडा बदल सकते हैं।",
+  "confirmFlagSelectionConfirm": "पुष्टि करें",
   "startAction": "शुरू करें",
   "levelHeading": "स्तर {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Bandiera del giocatore",
   "selectPlayerFlag": "Scegli la tua bandiera",
   "confirmFlagSelectionTitle": "Conferma la tua bandiera",
-  "confirmFlagSelectionMessage": "Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.",
+  "confirmFlagSelectionMessage": "Sei sicuro di voler scegliere questa bandiera? Potrai cambiare la tua bandiera più tardi nelle impostazioni del gioco.",
+  "confirmFlagSelectionConfirm": "Conferma",
   "startAction": "Inizio",
   "levelHeading": "Livello {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "プレイヤーの旗",
   "selectPlayerFlag": "自分の旗を選択",
   "confirmFlagSelectionTitle": "フラグを確認",
-  "confirmFlagSelectionMessage": "フラグは後でゲーム設定で変更できます。",
+  "confirmFlagSelectionMessage": "この旗を選択してもよろしいですか？後でゲーム設定で旗を変更できます。",
+  "confirmFlagSelectionConfirm": "確認する",
   "startAction": "始める",
   "levelHeading": "レベル {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "მოთამაშის დროშა",
   "selectPlayerFlag": "აირჩიე შენი დროშა",
   "confirmFlagSelectionTitle": "დაადასტურე შენი დროშა",
-  "confirmFlagSelectionMessage": "შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.",
+  "confirmFlagSelectionMessage": "დარწმუნებული ხარ, რომ ამ დროშას ირჩევ? შეგიძლია მოგვიანებით შეცვალო დროშა თამაშის პარამეტრებში.",
+  "confirmFlagSelectionConfirm": "დადასტურება",
   "startAction": "დაწყება",
   "levelHeading": "დონე {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "플레이어 깃발",
   "selectPlayerFlag": "깃발을 선택하세요",
   "confirmFlagSelectionTitle": "깃발 확인",
-  "confirmFlagSelectionMessage": "나중에 게임 설정에서 깃발을 변경할 수 있습니다.",
+  "confirmFlagSelectionMessage": "이 깃발을 선택하시겠습니까? 나중에 게임 설정에서 깃발을 변경할 수 있습니다.",
+  "confirmFlagSelectionConfirm": "확인",
   "startAction": "시작",
   "levelHeading": "레벨 {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Флаг игрока",
   "selectPlayerFlag": "Выбери свой флаг",
   "confirmFlagSelectionTitle": "Подтвердите флаг",
-  "confirmFlagSelectionMessage": "Вы сможете сменить флаг позже в настройках игры.",
+  "confirmFlagSelectionMessage": "Вы уверены, что хотите выбрать этот флаг? Флаг можно будет изменить в настройках игры.",
+  "confirmFlagSelectionConfirm": "Подтверждаю",
   "startAction": "Начать",
   "levelHeading": "Уровень {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "Прапор гравця",
   "selectPlayerFlag": "Обери свій прапор",
   "confirmFlagSelectionTitle": "Підтвердь свій прапор",
-  "confirmFlagSelectionMessage": "Ти зможеш змінити прапор пізніше в налаштуваннях гри.",
+  "confirmFlagSelectionMessage": "Ти впевнений, що хочеш обрати цей прапор? Ти зможеш змінити прапор пізніше в налаштуваннях гри.",
+  "confirmFlagSelectionConfirm": "Підтверджую",
   "startAction": "Почати",
   "levelHeading": "Рівень {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -89,7 +89,8 @@
   "playerFlagSettingTitle": "玩家旗帜",
   "selectPlayerFlag": "选择你的旗帜",
   "confirmFlagSelectionTitle": "确认你的旗帜",
-  "confirmFlagSelectionMessage": "你可以稍后在游戏设置中更改你的旗帜。",
+  "confirmFlagSelectionMessage": "你确定要选择这面旗帜吗？你可以稍后在游戏设置中更改你的旗帜。",
+  "confirmFlagSelectionConfirm": "确认",
   "startAction": "开始",
   "levelHeading": "等级 {level} — {difficulty}",
   "@levelHeading": {


### PR DESCRIPTION
## Summary
- update the battle flag selection confirmation dialog to use a dedicated localized confirmation label
- expand the confirmation message so it warns players before finalizing their first flag choice
- refresh all localization files with the new confirmation copy across supported languages

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d163c7fef08326b431a109aaf9be31