### PR TITLE
Center completed day star icon in calendar

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -2086,13 +2086,16 @@ class _CalendarDayButton extends StatelessWidget {
           color: selected ? cs.primary : Colors.transparent,
           border: border,
         ),
+        alignment: Alignment.center,
         padding: const EdgeInsets.all(3),
         child: Material(
           color: Colors.transparent,
           child: InkWell(
             customBorder: const CircleBorder(),
             onTap: locked ? null : onTap,
-            child: Center(child: dayContent),
+            child: SizedBox.expand(
+              child: Center(child: dayContent),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- align the calendar day container so the completed-day star renders in the exact middle of the circular marker
- expand the tappable area while centering its content to keep the star perfectly positioned during animations

## Testing
- flutter analyze *(fails: Flutter is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1782837a08326b4ad701dc45b2527