### PR TITLE
Adjust championship scoring and difficulty scaling

### DIFF
--- a/lib/championship/championship_page.dart
+++ b/lib/championship/championship_page.dart
@@ -67,22 +67,10 @@ class ChampionshipPage extends StatelessWidget {
 
   void _startChampionshipGame(BuildContext context) {
     final championship = context.read<ChampionshipModel>();
-    final rounds = championship.rounds;
-    ChampionshipRound? target;
-    for (final round in rounds) {
-      if (round.status == ChampionshipRoundStatus.inProgress) {
-        target = round;
-        break;
-      }
-    }
-    target ??= rounds.firstWhere(
-      (round) => round.status != ChampionshipRoundStatus.completed,
-      orElse: () => rounds.first,
-    );
-
-    championship.startRound(target.difficulty);
+    final difficulty = championship.recommendedDifficulty;
+    championship.startRound(difficulty);
     final app = context.read<AppState>();
-    app.startGame(target.difficulty);
+    app.startGame(difficulty);
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const GamePage()),


### PR DESCRIPTION
## Summary
- award a fixed 350-point bonus for every championship victory
- compute the recommended championship difficulty from the current rank and score, updating round state accordingly
- launch championship games using the recommended difficulty tier

## Testing
- flutter analyze *(not available in container)*
- flutter test *(not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d18e60fe488326874c5a358ab0259f