### PR TITLE
Adjust game banner sizing and control panel padding

### DIFF
--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -24,9 +24,9 @@ const double _kStatusBarOuterPadding = 10.0;
 const double _kGameContentTopPadding = 16.0;
 const double _kGameContentBottomPadding = 40.0;
 const double _kBoardToControlsSpacing = 8.0;
-const double _kStatusBarBannerScale = 1.05;
-const double _kBoardBannerScale = 1.06;
-const double _kControlPanelBannerScale = 1.05;
+const double _kStatusBarBannerScale = 1.1025;
+const double _kBoardBannerScale = 1.113;
+const double _kControlPanelBannerScale = 1.1025;
 const double _kCompactHeightBreakpoint = 720.0;
 const double _kTextHeightMultiplier = 1.1;
 

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -10,7 +10,7 @@ import '../undo_ad_controller.dart';
 
 const double _actionButtonRadiusValue = 20;
 const double _actionBadgeRadiusValue = 12;
-const double kControlPanelVerticalSpacing = 8.0;
+const double kControlPanelVerticalSpacing = 10.0;
 const double _kCompactHeightBreakpoint = 720.0;
 
 class ControlPanel extends StatelessWidget {
@@ -430,7 +430,7 @@ class _NumberPad extends StatelessWidget {
 
     final baseHorizontalPadding = isTablet ? 20.0 : 8.0;
     final horizontalPadding = baseHorizontalPadding / scale;
-    final verticalPadding = (isTablet ? 20.0 : 16.0) * scale * effectiveHeightFactor;
+    final verticalPadding = (isTablet ? 18.0 : 14.0) * scale * effectiveHeightFactor;
     final double radiusValue =
         math.max(18.0, 28 * scale * effectiveHeightFactor);
     final borderRadius = BorderRadius.circular(radiusValue);
@@ -749,7 +749,7 @@ double estimateControlPanelHeight({
   final double spacing = kControlPanelVerticalSpacing * scale * heightFactor;
   final double horizontalPadding = (isTablet ? 20.0 : 8.0) / scale;
   final double verticalPadding =
-      (isTablet ? 20.0 : 16.0) * scale * heightFactor;
+      (isTablet ? 18.0 : 14.0) * scale * heightFactor;
 
   final double innerWidth = math.max(0.0, maxWidth - horizontalPadding * 2);
 


### PR DESCRIPTION
## Summary
- slightly tighten the control panel number pad by reducing its vertical padding while keeping spacing calculations in sync
- bump the game screen banner scale factors by 5% so the status bar, board, and controls render larger

## Testing
- `flutter test` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bfec1a608326ab2f7e2efa954755