### PR TITLE
Integrate AdMob rewarded ads for undo

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
@@ -9,7 +11,7 @@ import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 import 'championship/championship_model.dart';
 import 'championship/championship_page.dart';
 import 'home_screen.dart';
-import 'models.dart';
+import 'models.dart' as models;
 import 'screens/intro_screen.dart';
 import 'theme.dart';
 import 'hint_ad_controller.dart';
@@ -18,11 +20,11 @@ import 'undo_ad_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final defaultLocale =
-      ui.PlatformDispatcher.instance.locale.toLanguageTag();
+  await _initializeMobileAds();
+  final defaultLocale = ui.PlatformDispatcher.instance.locale.toLanguageTag();
   await initializeDateFormatting(defaultLocale);
 
-  final appState = AppState();
+  final appState = models.AppState();
   await appState.load();
 
   runApp(
@@ -47,15 +49,29 @@ Future<void> main() async {
   );
 }
 
+Future<void> _initializeMobileAds() async {
+  if (kIsWeb) {
+    return;
+  }
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.android:
+    case TargetPlatform.iOS:
+      await MobileAds.instance.initialize();
+    default:
+      return;
+  }
+}
+
 class SudokuApp extends StatelessWidget {
   const SudokuApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final app = context.watch<AppState>();
+    final app = context.watch<models.AppState>();
     final activeTheme = app.resolvedTheme();
-    final theme = buildSudokuTheme(activeTheme)
-        .copyWith(pageTransitionsTheme: _pageTransitionsTheme);
+    final theme = buildSudokuTheme(
+      activeTheme,
+    ).copyWith(pageTransitionsTheme: _pageTransitionsTheme);
 
     return MaterialApp(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -12,8 +12,7 @@ import '../undo_ad_controller.dart';
 const double _actionButtonRadiusValue = 20;
 const double _actionBadgeRadiusValue = 12;
 const double _kControlPanelScaleIncrease = 1.05;
-const double kControlPanelVerticalSpacing =
-    10.0 / _kControlPanelScaleIncrease;
+const double kControlPanelVerticalSpacing = 10.0 / _kControlPanelScaleIncrease;
 // Targets roughly a 7% reduction in the keypad banner height while
 // preserving the digit sizing.
 const double _kNumberPadVerticalPaddingScale = 0.7125;
@@ -22,7 +21,8 @@ const double _kNumberPadSpacingCompensationScale =
     0.05 / _kControlPanelScaleIncrease;
 const double _kCompactHeightBreakpoint = 720.0;
 
-double _numberPadBasePadding({required bool isTablet}) => isTablet ? 18.0 : 14.0;
+double _numberPadBasePadding({required bool isTablet}) =>
+    isTablet ? 18.0 : 14.0;
 
 double _resolveHeightFactor({
   required bool isTablet,
@@ -72,14 +72,18 @@ ControlPanelLayoutConfig resolveControlPanelLayoutConfig({
   required bool compactLayout,
   required double screenHeight,
 }) {
-  final heightFactor =
-      _resolveHeightFactor(isTablet: isTablet, compactLayout: compactLayout, screenHeight: screenHeight);
+  final heightFactor = _resolveHeightFactor(
+    isTablet: isTablet,
+    compactLayout: compactLayout,
+    screenHeight: screenHeight,
+  );
   final effectiveHeightFactor = _resolveEffectiveHeightFactor(
     isTablet: isTablet,
     heightFactor: heightFactor,
     screenHeight: screenHeight,
   );
-  final basePadding = _numberPadBasePadding(isTablet: isTablet) * scale * effectiveHeightFactor;
+  final basePadding =
+      _numberPadBasePadding(isTablet: isTablet) * scale * effectiveHeightFactor;
   final verticalPadding = basePadding * _kNumberPadVerticalPaddingScale;
   final spacingCompensation = basePadding * _kNumberPadSpacingCompensationScale;
 
@@ -95,11 +99,7 @@ class ControlPanel extends StatelessWidget {
   final double scale;
   final bool compactLayout;
 
-  const ControlPanel({
-    super.key,
-    this.scale = 1.0,
-    this.compactLayout = false,
-  });
+  const ControlPanel({super.key, this.scale = 1.0, this.compactLayout = false});
 
   @override
   Widget build(BuildContext context) {
@@ -148,13 +148,21 @@ class _ActionRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Expanded(child: _UndoButton(scale: scale, heightFactor: heightFactor)),
+        Expanded(
+          child: _UndoButton(scale: scale, heightFactor: heightFactor),
+        ),
         SizedBox(width: 10 * scale * heightFactor),
-        Expanded(child: _EraseButton(scale: scale, heightFactor: heightFactor)),
+        Expanded(
+          child: _EraseButton(scale: scale, heightFactor: heightFactor),
+        ),
         SizedBox(width: 10 * scale * heightFactor),
-        Expanded(child: _NotesButton(scale: scale, heightFactor: heightFactor)),
+        Expanded(
+          child: _NotesButton(scale: scale, heightFactor: heightFactor),
+        ),
         SizedBox(width: 10 * scale * heightFactor),
-        Expanded(child: _HintButton(scale: scale, heightFactor: heightFactor)),
+        Expanded(
+          child: _HintButton(scale: scale, heightFactor: heightFactor),
+        ),
       ],
     );
   }
@@ -168,6 +176,8 @@ class _UndoButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
     return Consumer<UndoAdController>(
       builder: (context, undoAds, _) {
@@ -175,8 +185,13 @@ class _UndoButton extends StatelessWidget {
         return Selector<AppState, bool>(
           selector: (_, app) => app.canUndoMove,
           builder: (context, canUndo, __) {
-            final undoEnabled =
-                canUndo && (!useUndoAd || undoAds.isAdAvailable);
+            final undoEnabled = canUndo;
+            final canShowAd = undoAds.isAdAvailable;
+            final badgeColor = useUndoAd
+                ? canShowAd
+                      ? cs.secondary
+                      : theme.disabledColor
+                : null;
             return _ActionButton(
               key: const ValueKey('action-undo'),
               scale: scale,
@@ -198,6 +213,10 @@ class _UndoButton extends StatelessWidget {
                       app.undoMove();
                     }
                   : null,
+              badgeWidget: useUndoAd
+                  ? const Icon(Icons.play_arrow_rounded)
+                  : null,
+              badgeColor: badgeColor,
             );
           },
         );
@@ -274,8 +293,8 @@ class _HintButton extends StatelessWidget {
             final badgeColor = hasHint
                 ? cs.secondary
                 : canShowAd
-                    ? cs.secondary
-                    : theme.disabledColor;
+                ? cs.secondary
+                : theme.disabledColor;
             return _ActionButton(
               key: const ValueKey('action-hint'),
               scale: scale,
@@ -285,21 +304,22 @@ class _HintButton extends StatelessWidget {
               onPressed: hasHint
                   ? context.read<AppState>().useHint
                   : canShowAd
-                      ? () async {
-                          final app = context.read<AppState>();
-                          final shown = await hintAds.showAd(context);
-                          if (!context.mounted) {
-                            return;
-                          }
-                          if (!shown) {
-                            return;
-                          }
-                          app.grantHint();
-                        }
-                      : null,
+                  ? () async {
+                      final app = context.read<AppState>();
+                      final shown = await hintAds.showAd(context);
+                      if (!context.mounted) {
+                        return;
+                      }
+                      if (!shown) {
+                        return;
+                      }
+                      app.grantHint();
+                    }
+                  : null,
               badge: hasHint ? hintsLeft.toString() : null,
-              badgeWidget:
-                  hasHint ? null : const Icon(Icons.play_arrow_rounded),
+              badgeWidget: hasHint
+                  ? null
+                  : const Icon(Icons.play_arrow_rounded),
               badgeColor: badgeColor,
             );
           },
@@ -355,13 +375,13 @@ class _ActionButton extends StatelessWidget {
     final textColor = isActive
         ? cs.primary
         : enabled
-            ? cs.onSurface
-            : disabledColor;
+        ? cs.onSurface
+        : disabledColor;
     final iconColor = isActive
         ? cs.primary
         : enabled
-            ? cs.onSurface
-            : disabledColor;
+        ? cs.onSurface
+        : disabledColor;
     final baseBadge = badgeColor ?? colors.actionButtonBadgeColor;
     final badgeForeground = enabled ? baseBadge : baseBadge.withOpacity(0.4);
     final badgeBackground = enabled
@@ -379,22 +399,22 @@ class _ActionButton extends StatelessWidget {
     final double sizeFactor = baseFactor.clamp(0.85, 1.0).toDouble();
     final double minHeight = 56.0 * scale;
     final double height = math.max(minHeight, 72 * scale * sizeFactor);
-    final double radiusValue =
-        math.max(12.0, _actionButtonRadiusValue * scale * sizeFactor);
-    final double badgeRadiusValue =
-        math.max(8.0, _actionBadgeRadiusValue * scale * sizeFactor);
+    final double radiusValue = math.max(
+      12.0,
+      _actionButtonRadiusValue * scale * sizeFactor,
+    );
+    final double badgeRadiusValue = math.max(
+      8.0,
+      _actionBadgeRadiusValue * scale * sizeFactor,
+    );
     final borderRadius = BorderRadius.circular(radiusValue);
     final badgeRadius = BorderRadius.circular(badgeRadiusValue);
     final double blurRadius = 10 * scale * sizeFactor;
     final double offsetY = 5 * scale * sizeFactor;
-    final double verticalPadding =
-        math.max(6.0, 10 * scale * sizeFactor);
-    final double horizontalPadding =
-        math.max(6.0, 8 * scale * sizeFactor);
-    final double badgeHorizontalPadding =
-        math.max(3.0, 6 * scale * sizeFactor);
-    final double badgeVerticalPadding =
-        math.max(1.0, 2 * scale * sizeFactor);
+    final double verticalPadding = math.max(6.0, 10 * scale * sizeFactor);
+    final double horizontalPadding = math.max(6.0, 8 * scale * sizeFactor);
+    final double badgeHorizontalPadding = math.max(3.0, 6 * scale * sizeFactor);
+    final double badgeVerticalPadding = math.max(1.0, 2 * scale * sizeFactor);
     final double iconSize = 24 * scale;
     final double spacing = math.max(4.0, 6 * scale * sizeFactor);
 
@@ -529,13 +549,13 @@ class _DigitVM {
 
   @override
   int get hashCode => Object.hash(
-        remaining,
-        selected,
-        highlighted,
-        enabled,
-        notesMode,
-        fontScale,
-      );
+    remaining,
+    selected,
+    highlighted,
+    enabled,
+    notesMode,
+    fontScale,
+  );
 }
 
 class _NumberPad extends StatelessWidget {
@@ -561,8 +581,10 @@ class _NumberPad extends StatelessWidget {
     final reduceMotion = media.disableAnimations;
     final baseHorizontalPadding = isTablet ? 20.0 : 8.0;
     final horizontalPadding = baseHorizontalPadding / scale;
-    final double radiusValue =
-        math.max(18.0, 28 * scale * effectiveHeightFactor);
+    final double radiusValue = math.max(
+      18.0,
+      28 * scale * effectiveHeightFactor,
+    );
     final borderRadius = BorderRadius.circular(radiusValue);
     final double blurRadius = 20 * scale * effectiveHeightFactor;
     final double offsetY = 12 * scale * effectiveHeightFactor;
@@ -609,12 +631,15 @@ class _NumberPad extends StatelessWidget {
           final double buttonWidth = availableWidth / 9;
           final double baseMinWidth = isTablet ? 56.0 : 48.0;
 
-          final double widthScale =
-              (buttonWidth / baseMinWidth).clamp(0.95, isTablet ? 1.6 : 1.35).toDouble();
+          final double widthScale = (buttonWidth / baseMinWidth)
+              .clamp(0.95, isTablet ? 1.6 : 1.35)
+              .toDouble();
           final double minHeight = isTablet ? 80.0 : 68.0;
           final double heightMultiplier = isTablet ? 1.18 : 1.12;
-          final double buttonHeight =
-              math.max(minHeight, buttonWidth * heightMultiplier);
+          final double buttonHeight = math.max(
+            minHeight,
+            buttonWidth * heightMultiplier,
+          );
           final double scaledButtonHeight =
               buttonHeight * scale * effectiveHeightFactor;
           final double labelSpacing = (scaledButtonHeight * 0.09)
@@ -759,25 +784,25 @@ class _NumberButton extends StatelessWidget {
     final background = !enabled
         ? colors.numberPadDisabledBackground
         : isSelected
-            ? colors.numberPadSelectedBackground
-            : isHighlighted
-                ? colors.numberPadHighlightBackground
-                : colors.numberPadBackground;
+        ? colors.numberPadSelectedBackground
+        : isHighlighted
+        ? colors.numberPadHighlightBackground
+        : colors.numberPadBackground;
     final borderColor = !enabled
         ? Color.alphaBlend(
             cs.onSurface.withOpacity(0.05),
             colors.numberPadBackground,
           )
         : isSelected
-            ? colors.numberPadSelectedBorder
-            : isHighlighted
-                ? colors.numberPadHighlightBorder
-                : colors.numberPadBorder;
+        ? colors.numberPadSelectedBorder
+        : isHighlighted
+        ? colors.numberPadHighlightBorder
+        : colors.numberPadBorder;
     final textColor = !enabled
         ? colors.numberPadDisabledText
         : notesMode && !isSelected && !isHighlighted
-            ? cs.onSurface.withOpacity(0.7)
-            : cs.onSurface;
+        ? cs.onSurface.withOpacity(0.7)
+        : cs.onSurface;
     final duration = reduceMotion
         ? Duration.zero
         : const Duration(milliseconds: 160);
@@ -788,12 +813,13 @@ class _NumberButton extends StatelessWidget {
     final remainingColor = !enabled
         ? colors.numberPadDisabledText
         : isHighlighted
-            ? colors.numberPadRemainingHighlight
-            : colors.numberPadRemaining;
+        ? colors.numberPadRemainingHighlight
+        : colors.numberPadRemaining;
     final baseRemainingSize = 12.0 * fontScale;
-    final remainingFontSize = (baseRemainingSize * math.max(1.0, widthScale * 0.92) * 1.02)
-        .clamp(10.0, 18.0)
-        .toDouble();
+    final remainingFontSize =
+        (baseRemainingSize * math.max(1.0, widthScale * 0.92) * 1.02)
+            .clamp(10.0, 18.0)
+            .toDouble();
     final shadow = isSelected
         ? [
             BoxShadow(
@@ -883,9 +909,12 @@ double estimateControlPanelHeight({
   final double heightFactor = layout.heightFactor;
   final double effectiveHeightFactor = layout.effectiveHeightFactor;
   final double topInset = layout.spacingCompensation;
-  final double actionRowHeight =
-      math.max(56.0 * scale, 72 * scale * heightFactor);
-  final double baseSpacing = kControlPanelVerticalSpacing * scale * heightFactor;
+  final double actionRowHeight = math.max(
+    56.0 * scale,
+    72 * scale * heightFactor,
+  );
+  final double baseSpacing =
+      kControlPanelVerticalSpacing * scale * heightFactor;
   final double horizontalPadding = (isTablet ? 20.0 : 8.0) / scale;
   final double verticalPadding = layout.numberPadVerticalPadding;
 
@@ -906,10 +935,13 @@ double estimateControlPanelHeight({
   final double buttonWidth = availableWidth / 9;
   final double minHeight = isTablet ? 80.0 : 68.0;
   final double heightMultiplier = isTablet ? 1.18 : 1.12;
-  final double buttonHeight = math.max(minHeight, buttonWidth * heightMultiplier);
-  final double scaledButtonHeight = buttonHeight * scale * effectiveHeightFactor;
+  final double buttonHeight = math.max(
+    minHeight,
+    buttonWidth * heightMultiplier,
+  );
+  final double scaledButtonHeight =
+      buttonHeight * scale * effectiveHeightFactor;
   final double numberPadHeight = verticalPadding * 2 + scaledButtonHeight;
 
   return topInset + actionRowHeight + baseSpacing + topInset + numberPadHeight;
 }
-

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_foundation
 import shared_preferences_foundation
+import video_player_avfoundation
+import webview_flutter_wkwebview
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
+  WebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "WebViewFlutterPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -86,6 +94,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -96,6 +109,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: "0d4a3744b5e8ed1b8be6a1b452d309f811688855a497c6113fc4400f922db603"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.6"
   intl:
     dependency: "direct main"
     description:
@@ -176,6 +205,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.18"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -341,6 +394,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "0d55b1f1a31e5ad4c4967bfaa8ade0240b07d20ee4af1dfef5f531056512961a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "59e5a457ddcc1688f39e9aef0efb62aa845cf0cbbac47e44ac9730dc079a2385"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.13"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: f9a780aac57802b2892f93787e5ea53b5f43cc57dc107bee9436458365be71cd
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.4"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: cf2a1d29a284db648fd66cbd18aacc157f9862d77d2cc790f6f9678a46c1db5a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:
@@ -357,6 +450,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "3c4eb4fcc252b40c2b5ce7be20d0481428b70f3ff589b0a8b8aaeb64c6bed701"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.2"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "63d26ee3aca7256a83ccb576a50272edd7cfc80573a4305caa98985feb493ee0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: fea63576b3b7e02b2df8b78ba92b48ed66caec2bb041e9a0b1cbd586d5d80bfd
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.23.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -367,4 +492,4 @@ packages:
     version: "1.1.0"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   intl: ^0.20.2
   path_provider: ^2.1.4
   video_player: ^2.9.2
+  google_mobile_ads: ^5.0.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -23,7 +23,9 @@ void main() {
       MultiProvider(
         providers: [
           ChangeNotifierProvider(create: (_) => AppState()),
-          ChangeNotifierProvider(create: (_) => UndoAdController()),
+          ChangeNotifierProvider(
+            create: (_) => UndoAdController(integrationEnabled: false),
+          ),
         ],
         child: const SudokuApp(),
       ),


### PR DESCRIPTION
## Summary
- add the google_mobile_ads dependency and initialize MobileAds during startup on supported platforms
- replace the undo ad stub with a real RewardedAd loader/show flow and gate undo behind ad playback
- update the undo button UI to show the ad badge and adjust tests to disable ads when running in widgets

## Testing
- flutter test *(fails: video_player platform interface is not implemented in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c73b20308326b06d6664ff017099