### PR TITLE
Update Android SDK version and fix privacy policy URI

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.sudoku.uzor"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -25,7 +25,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 21
-        targetSdk = 35
+        targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/lib/widgets/privacy_policy_dialog.dart
+++ b/lib/widgets/privacy_policy_dialog.dart
@@ -7,7 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../flutter_gen/gen_l10n/app_localizations.dart';
 import '../layout/layout_scale.dart';
 
-const _privacyPolicyUri = Uri.parse(
+final _privacyPolicyUri = Uri.parse(
   'https://github.com/UzorPlay/privacy-policy/blob/main/privacy-policy.md',
 );
 


### PR DESCRIPTION
## Summary
- update the Android module to compile and target SDK 36
- change the privacy policy URI to use a non-const declaration to avoid runtime errors

## Testing
- flutter clean *(fails: Flutter is not installed in the execution environment)*
- flutter pub get *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ea5d89d48326bf326132e8a4a35d