### PR TITLE
Restore placeholder ad flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,7 @@
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
@@ -20,7 +18,6 @@ import 'undo_ad_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await _initializeMobileAds();
   final defaultLocale = ui.PlatformDispatcher.instance.locale.toLanguageTag();
   await initializeDateFormatting(defaultLocale);
 
@@ -47,19 +44,6 @@ Future<void> main() async {
       child: const SudokuApp(),
     ),
   );
-}
-
-Future<void> _initializeMobileAds() async {
-  if (kIsWeb) {
-    return;
-  }
-  switch (defaultTargetPlatform) {
-    case TargetPlatform.android:
-    case TargetPlatform.iOS:
-      await MobileAds.instance.initialize();
-    default:
-      return;
-  }
 }
 
 class SudokuApp extends StatelessWidget {

--- a/lib/undo_ad_controller.dart
+++ b/lib/undo_ad_controller.dart
@@ -2,58 +2,38 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
 class UndoAdController extends ChangeNotifier {
-  UndoAdController({bool? integrationEnabled, String? adUnitId})
-    : _integrationEnabled =
-          integrationEnabled ??
-          const bool.fromEnvironment('enableUndoAd', defaultValue: true),
-      _adUnitId = adUnitId ?? _kDefaultAdUnitId {
-    if (useAdFlow) {
-      unawaited(_loadAd());
-    }
-  }
-
-  static const String _kDefaultAdUnitId =
-      'ca-app-pub-3940256099942544/5224354917';
+  UndoAdController({
+    bool? integrationEnabled,
+    Duration adDuration = const Duration(seconds: 5),
+  })  : _integrationEnabled =
+            integrationEnabled ?? const bool.fromEnvironment('enableUndoAd'),
+        _adDuration = adDuration;
 
   final bool _integrationEnabled;
-  final String _adUnitId;
-
-  RewardedAd? _rewardedAd;
-  Future<bool>? _loadingAd;
-  Future<bool>? _pendingAd;
+  final Duration _adDuration;
+  bool _adAvailable = true;
   bool _showingAd = false;
+  Future<bool>? _pendingAd;
 
-  bool get useAdFlow {
-    if (!_integrationEnabled) {
-      return false;
-    }
-    if (kIsWeb) {
-      return false;
-    }
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.iOS:
-        return true;
-      default:
-        return false;
-    }
-  }
+  bool get useAdFlow => kReleaseMode && _integrationEnabled;
 
-  bool get isAdAvailable =>
-      !useAdFlow ? true : _rewardedAd != null && !_showingAd;
+  bool get isAdAvailable => !useAdFlow ? true : _adAvailable && !_showingAd;
 
-  Future<bool> showAd(BuildContext _) {
+  Future<bool> showAd(BuildContext context) {
     if (!useAdFlow) {
       return Future.value(true);
     }
     if (_pendingAd != null) {
       return _pendingAd!;
     }
+    if (!isAdAvailable) {
+      return Future.value(false);
+    }
 
-    final future = _performShowAd();
+    final future = _performShowAd(context);
     _pendingAd = future;
     future.whenComplete(() {
       _pendingAd = null;
@@ -61,116 +41,179 @@ class UndoAdController extends ChangeNotifier {
     return future;
   }
 
-  Future<bool> _performShowAd() async {
-    final loaded = await _ensureAdLoaded();
-    if (!loaded) {
-      return false;
-    }
-    final ad = _rewardedAd;
-    if (ad == null) {
-      return false;
-    }
-
-    bool rewardEarned = false;
-    final completer = Completer<bool>();
-
+  Future<bool> _performShowAd(BuildContext context) async {
+    _adAvailable = false;
     _showingAd = true;
     notifyListeners();
 
-    ad.fullScreenContentCallback = FullScreenContentCallback(
-      onAdDismissedFullScreenContent: (RewardedAd ad) {
-        _handleAdClosed(ad, rewardEarned, completer);
-      },
-      onAdFailedToShowFullScreenContent: (RewardedAd ad, AdError error) {
-        _handleAdFailedToShow(ad, completer);
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        final l10n = AppLocalizations.of(context)!;
+        return _UndoAdDialog(
+          duration: _adDuration,
+          title: l10n.undoAdTitle,
+          description: l10n.undoAdDescription,
+          countdownBuilder: l10n.undoAdCountdown,
+        );
       },
     );
 
-    try {
-      ad.show(
-        onUserEarnedReward: (AdWithoutView ad, RewardItem reward) {
-          rewardEarned = true;
-        },
-      );
-    } on Object {
-      _handleAdFailedToShow(ad, completer);
+    if (!context.mounted) {
+      _showingAd = false;
+      _adAvailable = true;
+      notifyListeners();
+      return false;
     }
 
-    return completer.future;
+    _showingAd = false;
+    _adAvailable = true;
+    notifyListeners();
+
+    return true;
   }
 
-  Future<bool> _ensureAdLoaded() async {
+  void updateAvailability(bool available) {
     if (!useAdFlow) {
-      return true;
+      return;
     }
-    if (_rewardedAd != null) {
-      return true;
+    if (_adAvailable == available) {
+      return;
     }
-    if (_loadingAd != null) {
-      return _loadingAd!;
-    }
-    return _loadAd();
-  }
-
-  Future<bool> _loadAd() {
-    final completer = Completer<bool>();
-    _loadingAd = completer.future;
-
-    RewardedAd.load(
-      adUnitId: _adUnitId,
-      request: const AdRequest(),
-      rewardedAdLoadCallback: RewardedAdLoadCallback(
-        onAdLoaded: (RewardedAd ad) {
-          _rewardedAd = ad;
-          _loadingAd = null;
-          notifyListeners();
-          completer.complete(true);
-        },
-        onAdFailedToLoad: (LoadAdError error) {
-          _rewardedAd = null;
-          _loadingAd = null;
-          notifyListeners();
-          completer.complete(false);
-        },
-      ),
-    );
-
-    return completer.future;
-  }
-
-  void _handleAdClosed(
-    RewardedAd ad,
-    bool rewardEarned,
-    Completer<bool> completer,
-  ) {
-    _showingAd = false;
-    ad.dispose();
-    _rewardedAd = null;
+    _adAvailable = available;
     notifyListeners();
-    if (useAdFlow) {
-      unawaited(_loadAd());
-    }
-    if (!completer.isCompleted) {
-      completer.complete(rewardEarned);
-    }
   }
+}
 
-  void _handleAdFailedToShow(RewardedAd ad, Completer<bool> completer) {
-    _showingAd = false;
-    ad.dispose();
-    _rewardedAd = null;
-    notifyListeners();
-    if (useAdFlow) {
-      unawaited(_loadAd());
+class _UndoAdDialog extends StatefulWidget {
+  const _UndoAdDialog({
+    required this.duration,
+    required this.title,
+    required this.description,
+    required this.countdownBuilder,
+  });
+
+  final Duration duration;
+  final String title;
+  final String description;
+  final String Function(int seconds) countdownBuilder;
+
+  @override
+  State<_UndoAdDialog> createState() => _UndoAdDialogState();
+}
+
+class _UndoAdDialogState extends State<_UndoAdDialog> {
+  late int _secondsLeft;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _secondsLeft = widget.duration.inSeconds;
+    if (_secondsLeft <= 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+        final navigator = Navigator.of(context, rootNavigator: true);
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
+      });
+      return;
     }
-    if (!completer.isCompleted) {
-      completer.complete(false);
-    }
+
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+
+      final remaining = widget.duration.inSeconds - timer.tick;
+      setState(() {
+        _secondsLeft = remaining;
+      });
+
+      if (remaining <= 0) {
+        timer.cancel();
+        if (!mounted) {
+          return;
+        }
+        final navigator = Navigator.of(context, rootNavigator: true);
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
+      }
+    });
   }
 
   @override
   void dispose() {
-    _rewardedAd?.dispose();
+    _timer?.cancel();
     super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final primary = cs.primary;
+
+    final total = widget.duration.inSeconds;
+    final seconds = (_secondsLeft.clamp(0, total)).toInt();
+    final progress = total == 0 ? 1.0 : (total - seconds) / total;
+
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: const BorderRadius.all(Radius.circular(24)),
+      ),
+      insetPadding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.ondemand_video, color: primary, size: 32),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    widget.title,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              widget.description,
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+              child: LinearProgressIndicator(
+                value: progress.clamp(0.0, 1.0),
+                minHeight: 10,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              widget.countdownBuilder(seconds),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,14 +109,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  google_mobile_ads:
-    dependency: "direct main"
-    description:
-      name: google_mobile_ads
-      sha256: "0d4a3744b5e8ed1b8be6a1b452d309f811688855a497c6113fc4400f922db603"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.3.1"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   intl: ^0.20.2
   path_provider: ^2.1.4
   video_player: ^2.9.2
-  google_mobile_ads: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- revert the undo ad controller to the original countdown dialog implementation
- remove google_mobile_ads dependency and startup initialization
- keep existing hint and life ad placeholders while restoring the proven flow

## Testing
- ⚠️ not run (flutter tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d3fdebc96c8326bcfde5c86680b725