### PR TITLE
Implement undo reward placeholder flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,7 @@ import 'screens/intro_screen.dart';
 import 'theme.dart';
 import 'hint_ad_controller.dart';
 import 'life_ad_controller.dart';
-import 'undo_ad_controller.dart';
+import 'undo_reward_controller.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -38,7 +38,7 @@ Future<void> main() async {
           lazy: false,
         ),
         ChangeNotifierProvider(create: (_) => LifeAdController()),
-        ChangeNotifierProvider(create: (_) => UndoAdController()),
+        ChangeNotifierProvider(create: (_) => UndoRewardController()),
         ChangeNotifierProvider(create: (_) => HintAdController()),
       ],
       child: const SudokuApp(),

--- a/lib/widgets/control_panel.dart
+++ b/lib/widgets/control_panel.dart
@@ -7,7 +7,7 @@ import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 import '../models.dart';
 import '../theme.dart';
 import '../hint_ad_controller.dart';
-import '../undo_ad_controller.dart';
+import '../undo_reward_controller.dart';
 
 const double _actionButtonRadiusValue = 20;
 const double _actionBadgeRadiusValue = 12;
@@ -179,16 +179,16 @@ class _UndoButton extends StatelessWidget {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
-    return Consumer<UndoAdController>(
-      builder: (context, undoAds, _) {
-        final useUndoAd = undoAds.useAdFlow;
+    return Consumer<UndoRewardController>(
+      builder: (context, undoRewards, _) {
+        final requiresReward = undoRewards.isRewardEnabled;
         return Selector<AppState, bool>(
           selector: (_, app) => app.canUndoMove,
           builder: (context, canUndo, __) {
             final undoEnabled = canUndo;
-            final canShowAd = undoAds.isAdAvailable;
-            final badgeColor = useUndoAd
-                ? canShowAd
+            final canShowReward = undoRewards.isRewardAvailable;
+            final badgeColor = requiresReward
+                ? canShowReward
                       ? cs.secondary
                       : theme.disabledColor
                 : null;
@@ -201,19 +201,20 @@ class _UndoButton extends StatelessWidget {
               onPressed: undoEnabled
                   ? () async {
                       final app = context.read<AppState>();
-                      if (useUndoAd) {
-                        final shown = await undoAds.showAd(context);
+                      if (requiresReward) {
+                        final rewarded =
+                            await undoRewards.showReward(context);
                         if (!context.mounted) {
                           return;
                         }
-                        if (!shown || !app.canUndoMove) {
+                        if (!rewarded || !app.canUndoMove) {
                           return;
                         }
                       }
                       app.undoMove();
                     }
                   : null,
-              badgeWidget: useUndoAd
+              badgeWidget: requiresReward
                   ? const Icon(Icons.play_arrow_rounded)
                   : null,
               badgeColor: badgeColor,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,7 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:sudoku2/main.dart';
 import 'package:sudoku2/models.dart';
-import 'package:sudoku2/undo_ad_controller.dart';
+import 'package:sudoku2/undo_reward_controller.dart';
 
 void main() {
   testWidgets('Домашний экран отображает основные секции', (tester) async {
@@ -24,7 +24,7 @@ void main() {
         providers: [
           ChangeNotifierProvider(create: (_) => AppState()),
           ChangeNotifierProvider(
-            create: (_) => UndoAdController(integrationEnabled: false),
+            create: (_) => UndoRewardController(enabled: false),
           ),
         ],
         child: const SudokuApp(),


### PR DESCRIPTION
## Summary
- replace the old undo ad controller with a reward placeholder controller that always drives the undo gate
- show a countdown dialog with a manual close button so undo only triggers after the placeholder completes
- update the control panel wiring and widget test to use the new controller

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d401ac4394832697874fe11b47f283