### PR TITLE
Add privacy policy confirmation flow

### DIFF
--- a/assets/privacy_policy/privacy-policy.md
+++ b/assets/privacy_policy/privacy-policy.md
@@ -1,0 +1,56 @@
+# Privacy Policy
+
+**UzorPlay** ("we", "our", "us") develops and publishes mobile games.  
+This Privacy Policy explains how we handle information when you use our games.
+
+---
+
+## Information We Collect
+- We **do not collect or store any personal data** such as name, email, phone number, or contacts.  
+- Our games may display advertising provided by **Google AdMob**. In this case, Google may collect certain technical data (such as device identifiers or approximate location) in order to show relevant ads.  
+- Apart from advertising, all game progress and settings are stored **only on your device** and are not sent to us.
+
+---
+
+## How We Use Information
+- We do not use or process personal information.  
+- Advertising is managed directly by Google AdMob in accordance with their [Privacy Policy](https://policies.google.com/privacy).
+
+---
+
+## Data Sharing
+- We do not sell, trade, or transfer your data to third parties.  
+- Only Google AdMob may process data for the purpose of serving ads.
+
+---
+
+## Children’s Privacy
+Our games are designed for a general audience. We do not knowingly collect personal information from children. Ads shown in our games are provided by Google and follow their family-friendly policies if enabled.
+
+---
+
+## Changes to This Policy
+We may update this Privacy Policy from time to time. Updates will be published at:  
+[https://uzorplay.github.io/privacy-policy](https://uzorplay.github.io/privacy-policy)
+
+---
+
+## Contact Us
+If you have questions about this Privacy Policy, you can contact us:  
+📧 UzorPlay@gmail.com  
+
+---
+
+### 🇷🇺 Политика конфиденциальности
+**UzorPlay** («мы») разрабатывает и публикует мобильные игры.  
+Мы **не собираем и не храним личные данные** пользователей.  
+Реклама может показываться через **Google AdMob**, и в этом случае Google обрабатывает технические данные устройства.  
+Все настройки и прогресс игр сохраняются только на вашем устройстве.  
+
+---
+
+### 🇺🇦 Політика конфіденційності
+**UzorPlay** («ми») розробляє та публікує мобільні ігри.  
+Ми **не збираємо і не зберігаємо особисті дані** користувачів.  
+Реклама може відображатися через **Google AdMob**, і в цьому випадку Google обробляє технічні дані пристрою.  
+Усі налаштування та прогрес ігор зберігаються лише на вашому пристрої.  

--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -312,6 +312,14 @@ abstract class AppLocalizations {
 
   String get done;
 
+  String get privacyPolicyTitle;
+
+  String get privacyPolicyAccept;
+
+  String get privacyPolicyClose;
+
+  String get privacyPolicyLoadError;
+
   String get failed;
 
   String rankBadgeChasing(int current, int delta, int target);
@@ -875,6 +883,18 @@ class AppLocalizationsDe extends AppLocalizations {
   String get done => "Fertig";
 
   @override
+  String get privacyPolicyTitle => "Datenschutzerklärung";
+
+  @override
+  String get privacyPolicyAccept => "Ich stimme zu";
+
+  @override
+  String get privacyPolicyClose => "Schließen";
+
+  @override
+  String get privacyPolicyLoadError => "Datenschutzerklärung konnte nicht geladen werden. Bitte versuche es erneut.";
+
+  @override
   String get failed => "Fehlgeschlagen";
 
   @override
@@ -1385,6 +1405,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get done => "Done";
+
+  @override
+  String get privacyPolicyTitle => "Privacy Policy";
+
+  @override
+  String get privacyPolicyAccept => "I accept";
+
+  @override
+  String get privacyPolicyClose => "Close";
+
+  @override
+  String get privacyPolicyLoadError => "Failed to load privacy policy. Please try again.";
 
   @override
   String get failed => "Failed";
@@ -1899,6 +1931,18 @@ class AppLocalizationsEs extends AppLocalizations {
   String get done => "Hecho";
 
   @override
+  String get privacyPolicyTitle => "Política de privacidad";
+
+  @override
+  String get privacyPolicyAccept => "Acepto";
+
+  @override
+  String get privacyPolicyClose => "Cerrar";
+
+  @override
+  String get privacyPolicyLoadError => "No se pudo cargar la política de privacidad. Inténtalo de nuevo.";
+
+  @override
   String get failed => "Fallido";
 
   @override
@@ -2409,6 +2453,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get done => "Terminé";
+
+  @override
+  String get privacyPolicyTitle => "Politique de confidentialité";
+
+  @override
+  String get privacyPolicyAccept => "J'accepte";
+
+  @override
+  String get privacyPolicyClose => "Fermer";
+
+  @override
+  String get privacyPolicyLoadError => "Impossible de charger la politique de confidentialité. Veuillez réessayer.";
 
   @override
   String get failed => "Échec";
@@ -2923,6 +2979,18 @@ class AppLocalizationsHi extends AppLocalizations {
   String get done => "पूर्ण";
 
   @override
+  String get privacyPolicyTitle => "गोपनीयता नीति";
+
+  @override
+  String get privacyPolicyAccept => "मैं सहमत हूँ";
+
+  @override
+  String get privacyPolicyClose => "बंद करें";
+
+  @override
+  String get privacyPolicyLoadError => "गोपनीयता नीति लोड नहीं हो सकी। कृपया दोबारा प्रयास करें।";
+
+  @override
   String get failed => "असफल";
 
   @override
@@ -3433,6 +3501,18 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get done => "Fatto";
+
+  @override
+  String get privacyPolicyTitle => "Informativa sulla privacy";
+
+  @override
+  String get privacyPolicyAccept => "Accetto";
+
+  @override
+  String get privacyPolicyClose => "Chiudi";
+
+  @override
+  String get privacyPolicyLoadError => "Impossibile caricare l'informativa sulla privacy. Riprova.";
 
   @override
   String get failed => "Fallito";
@@ -3947,6 +4027,18 @@ class AppLocalizationsJa extends AppLocalizations {
   String get done => "終わり";
 
   @override
+  String get privacyPolicyTitle => "プライバシーポリシー";
+
+  @override
+  String get privacyPolicyAccept => "同意します";
+
+  @override
+  String get privacyPolicyClose => "閉じる";
+
+  @override
+  String get privacyPolicyLoadError => "プライバシーポリシーを読み込めませんでした。もう一度お試しください。";
+
+  @override
   String get failed => "失敗した";
 
   @override
@@ -4459,6 +4551,18 @@ class AppLocalizationsKa extends AppLocalizations {
   String get done => "დასრულდა";
 
   @override
+  String get privacyPolicyTitle => "კონფიდენციალურობის პოლიტიკა";
+
+  @override
+  String get privacyPolicyAccept => "ვეთანხმები";
+
+  @override
+  String get privacyPolicyClose => "დახურვა";
+
+  @override
+  String get privacyPolicyLoadError => "კონფიდენციალურობის პოლიტიკის ჩატვირთვა ვერ მოხერხდა. გთხოვთ, სცადეთ ხელახლა.";
+
+  @override
   String get failed => "ვერ შესრულდა";
 
   @override
@@ -4969,6 +5073,18 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get done => "완료";
+
+  @override
+  String get privacyPolicyTitle => "개인정보 처리방침";
+
+  @override
+  String get privacyPolicyAccept => "동의합니다";
+
+  @override
+  String get privacyPolicyClose => "닫기";
+
+  @override
+  String get privacyPolicyLoadError => "개인정보 처리방침을 불러오지 못했습니다. 다시 시도해 주세요.";
 
   @override
   String get failed => "실패한";
@@ -5487,6 +5603,18 @@ class AppLocalizationsRu extends AppLocalizations {
   String get done => "Готово";
 
   @override
+  String get privacyPolicyTitle => "Политика конфиденциальности";
+
+  @override
+  String get privacyPolicyAccept => "Принимаю";
+
+  @override
+  String get privacyPolicyClose => "Закрыть";
+
+  @override
+  String get privacyPolicyLoadError => "Не удалось загрузить политику конфиденциальности. Повторите попытку.";
+
+  @override
   String get failed => "Ошибка";
 
   @override
@@ -6003,6 +6131,18 @@ class AppLocalizationsUk extends AppLocalizations {
   String get done => "Готово";
 
   @override
+  String get privacyPolicyTitle => "Політика конфіденційності";
+
+  @override
+  String get privacyPolicyAccept => "Приймаю";
+
+  @override
+  String get privacyPolicyClose => "Закрити";
+
+  @override
+  String get privacyPolicyLoadError => "Не вдалося завантажити політику конфіденційності. Спробуйте ще раз.";
+
+  @override
   String get failed => "Помилка";
 
   @override
@@ -6511,6 +6651,18 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get done => "完成";
+
+  @override
+  String get privacyPolicyTitle => "隐私政策";
+
+  @override
+  String get privacyPolicyAccept => "我同意";
+
+  @override
+  String get privacyPolicyClose => "关闭";
+
+  @override
+  String get privacyPolicyLoadError => "无法加载隐私政策。请重试。";
 
   @override
   String get failed => "失败";

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -15,6 +15,7 @@ import 'theme.dart';
 import 'championship/championship_model.dart';
 import 'layout/layout_scale.dart';
 import 'widgets/how_to_play_dialog.dart';
+import 'widgets/privacy_policy_dialog.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -38,6 +39,22 @@ class _HomeScreenState extends State<HomeScreen> {
       return;
     }
     final app = context.read<AppState>();
+    if (!app.privacyPolicyAccepted) {
+      final acceptedPolicy = await showPrivacyPolicyDialog(
+        context,
+        requireAcceptance: true,
+      );
+      if (!mounted) {
+        return;
+      }
+      if (!acceptedPolicy) {
+        return;
+      }
+      app.markPrivacyPolicyAccepted();
+    }
+    if (!mounted) {
+      return;
+    }
     if (app.tutorialSeen) {
       return;
     }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -254,6 +254,10 @@
   "confirm": "Bestätigen",
   "cancel": "Abbrechen",
   "done": "Fertig",
+  "privacyPolicyTitle": "Datenschutzerklärung",
+  "privacyPolicyAccept": "Ich stimme zu",
+  "privacyPolicyClose": "Schließen",
+  "privacyPolicyLoadError": "Datenschutzerklärung konnte nicht geladen werden. Bitte versuche es erneut.",
   "failed": "Fehlgeschlagen",
   "rankBadgeChasing": "Rang #{current} • +{delta} bis #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -255,6 +255,10 @@
   "confirm": "Confirm",
   "cancel": "Cancel",
   "done": "Done",
+  "privacyPolicyTitle": "Privacy Policy",
+  "privacyPolicyAccept": "I accept",
+  "privacyPolicyClose": "Close",
+  "privacyPolicyLoadError": "Failed to load privacy policy. Please try again.",
   "failed": "Failed",
   "rankBadgeChasing": "Rank #{current} • +{delta} to #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -254,6 +254,10 @@
   "confirm": "Confirmar",
   "cancel": "Cancelar",
   "done": "Hecho",
+  "privacyPolicyTitle": "Política de privacidad",
+  "privacyPolicyAccept": "Acepto",
+  "privacyPolicyClose": "Cerrar",
+  "privacyPolicyLoadError": "No se pudo cargar la política de privacidad. Inténtalo de nuevo.",
   "failed": "Fallido",
   "rankBadgeChasing": "Rango #{current} • +{delta} hacia #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -254,6 +254,10 @@
   "confirm": "Confirmer",
   "cancel": "Annuler",
   "done": "Terminé",
+  "privacyPolicyTitle": "Politique de confidentialité",
+  "privacyPolicyAccept": "J'accepte",
+  "privacyPolicyClose": "Fermer",
+  "privacyPolicyLoadError": "Impossible de charger la politique de confidentialité. Veuillez réessayer.",
   "failed": "Échec",
   "rankBadgeChasing": "Rang #{current} • +{delta} vers #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -254,6 +254,10 @@
   "confirm": "पुष्टि करें",
   "cancel": "रद्द करें",
   "done": "पूर्ण",
+  "privacyPolicyTitle": "गोपनीयता नीति",
+  "privacyPolicyAccept": "मैं सहमत हूँ",
+  "privacyPolicyClose": "बंद करें",
+  "privacyPolicyLoadError": "गोपनीयता नीति लोड नहीं हो सकी। कृपया दोबारा प्रयास करें।",
   "failed": "असफल",
   "rankBadgeChasing": "रैंक #{current} • +{delta} से #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -254,6 +254,10 @@
   "confirm": "Confermare",
   "cancel": "Cancellare",
   "done": "Fatto",
+  "privacyPolicyTitle": "Informativa sulla privacy",
+  "privacyPolicyAccept": "Accetto",
+  "privacyPolicyClose": "Chiudi",
+  "privacyPolicyLoadError": "Impossibile caricare l'informativa sulla privacy. Riprova.",
   "failed": "Fallito",
   "rankBadgeChasing": "Classifica #{current} • +{delta} fino a #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -254,6 +254,10 @@
   "confirm": "確認する",
   "cancel": "キャンセル",
   "done": "終わり",
+  "privacyPolicyTitle": "プライバシーポリシー",
+  "privacyPolicyAccept": "同意します",
+  "privacyPolicyClose": "閉じる",
+  "privacyPolicyLoadError": "プライバシーポリシーを読み込めませんでした。もう一度お試しください。",
   "failed": "失敗した",
   "rankBadgeChasing": "ランク #{current} • +{delta} で #{target}へ",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -254,6 +254,10 @@
   "confirm": "დადასტურება",
   "cancel": "გაუქმება",
   "done": "დასრულდა",
+  "privacyPolicyTitle": "კონფიდენციალურობის პოლიტიკა",
+  "privacyPolicyAccept": "ვეთანხმები",
+  "privacyPolicyClose": "დახურვა",
+  "privacyPolicyLoadError": "კონფიდენციალურობის პოლიტიკის ჩატვირთვა ვერ მოხერხდა. გთხოვთ, სცადეთ ხელახლა.",
   "failed": "ვერ შესრულდა",
   "rankBadgeChasing": "რეიტინგი #{current} • +{delta} რათა მიაღწიოთ #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -254,6 +254,10 @@
   "confirm": "확인하다",
   "cancel": "취소",
   "done": "완료",
+  "privacyPolicyTitle": "개인정보 처리방침",
+  "privacyPolicyAccept": "동의합니다",
+  "privacyPolicyClose": "닫기",
+  "privacyPolicyLoadError": "개인정보 처리방침을 불러오지 못했습니다. 다시 시도해 주세요.",
   "failed": "실패한",
   "rankBadgeChasing": "랭크 #{current} • +{delta} #{target}까지",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -254,6 +254,10 @@
   "confirm": "Подтвердить",
   "cancel": "Отмена",
   "done": "Готово",
+  "privacyPolicyTitle": "Политика конфиденциальности",
+  "privacyPolicyAccept": "Принимаю",
+  "privacyPolicyClose": "Закрыть",
+  "privacyPolicyLoadError": "Не удалось загрузить политику конфиденциальности. Повторите попытку.",
   "failed": "Ошибка",
   "rankBadgeChasing": "Место #{current} • +{delta} до #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -254,6 +254,10 @@
   "confirm": "Підтвердити",
   "cancel": "Скасувати",
   "done": "Готово",
+  "privacyPolicyTitle": "Політика конфіденційності",
+  "privacyPolicyAccept": "Приймаю",
+  "privacyPolicyClose": "Закрити",
+  "privacyPolicyLoadError": "Не вдалося завантажити політику конфіденційності. Спробуйте ще раз.",
   "failed": "Помилка",
   "rankBadgeChasing": "Місце #{current} • +{delta} до #{target}",
   "@rankBadgeChasing": {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -254,6 +254,10 @@
   "confirm": "确认",
   "cancel": "取消",
   "done": "完成",
+  "privacyPolicyTitle": "隐私政策",
+  "privacyPolicyAccept": "我同意",
+  "privacyPolicyClose": "关闭",
+  "privacyPolicyLoadError": "无法加载隐私政策。请重试。",
   "failed": "失败",
   "rankBadgeChasing": "第 {current} 名 • 还差 {delta} 分到第 {target} 名",
   "@rankBadgeChasing": {

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -270,6 +270,7 @@ class AppState extends ChangeNotifier {
 
   String? playerFlag;
   bool tutorialSeen = false;
+  bool privacyPolicyAccepted = false;
 
   int totalStars = 0;
   int battleGamesWon = 0;
@@ -470,6 +471,8 @@ class AppState extends ChangeNotifier {
 
       soundsEnabled = prefs.getBool('soundsEnabled') ?? soundsEnabled;
       vibrationEnabled = prefs.getBool('vibrationEnabled') ?? vibrationEnabled;
+      privacyPolicyAccepted =
+          prefs.getBool('privacyPolicyAccepted') ?? privacyPolicyAccepted;
       tutorialSeen = prefs.getBool('tutorialSeen') ?? tutorialSeen;
       final savedGame = prefs.getString('currentGame');
       if (savedGame != null) {
@@ -731,6 +734,15 @@ class AppState extends ChangeNotifier {
     vibrationEnabled = enabled;
     _persist((prefs) async {
       await prefs.setBool('vibrationEnabled', enabled);
+    });
+    notifyListeners();
+  }
+
+  void markPrivacyPolicyAccepted() {
+    if (privacyPolicyAccepted) return;
+    privacyPolicyAccepted = true;
+    _persist((prefs) async {
+      await prefs.setBool('privacyPolicyAccepted', true);
     });
     notifyListeners();
   }

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -9,6 +9,7 @@ import 'championship/championship_model.dart';
 import 'language_settings_page.dart';
 import 'models.dart';
 import 'widgets/how_to_play_dialog.dart';
+import 'widgets/privacy_policy_dialog.dart';
 import 'widgets/theme_menu.dart';
 import 'layout/layout_scale.dart';
 
@@ -144,6 +145,17 @@ class SettingsPage extends StatelessWidget {
                 applicationName: l10n.appTitle,
                 applicationVersion: _appVersion,
                 applicationLegalese: l10n.aboutLegalese,
+              );
+            },
+          ),
+          ListTile(
+            key: const ValueKey('settings-privacy-policy'),
+            leading: Icon(Icons.privacy_tip_outlined, size: iconSize),
+            title: Text(l10n.privacyPolicyTitle),
+            onTap: () async {
+              await showPrivacyPolicyDialog(
+                context,
+                requireAcceptance: false,
               );
             },
           ),

--- a/lib/widgets/privacy_policy_dialog.dart
+++ b/lib/widgets/privacy_policy_dialog.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import '../flutter_gen/gen_l10n/app_localizations.dart';
+import '../layout/layout_scale.dart';
+
+const _privacyPolicyAsset = 'assets/privacy_policy/privacy-policy.md';
+
+Future<bool> showPrivacyPolicyDialog(
+  BuildContext context, {
+  required bool requireAcceptance,
+}) async {
+  final result = await showDialog<bool>(
+    context: context,
+    barrierDismissible: !requireAcceptance,
+    builder: (context) {
+      return _PrivacyPolicyDialog(requireAcceptance: requireAcceptance);
+    },
+  );
+  return result ?? false;
+}
+
+class _PrivacyPolicyDialog extends StatelessWidget {
+  final bool requireAcceptance;
+
+  const _PrivacyPolicyDialog({required this.requireAcceptance});
+
+  Future<String> _loadPolicy(BuildContext context) {
+    return DefaultAssetBundle.of(context).loadString(_privacyPolicyAsset);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final scale = context.layoutScale;
+    final colors = theme.colorScheme;
+    final titleStyle = theme.textTheme.headlineSmall?.copyWith(
+      fontWeight: FontWeight.w700,
+    );
+    final bodyStyle = theme.textTheme.bodyMedium?.copyWith(height: 1.4);
+    final contentHeight = (360 * scale).clamp(280.0, 520.0) as double;
+
+    return WillPopScope(
+      onWillPop: () async => !requireAcceptance,
+      child: Dialog(
+        insetPadding: EdgeInsets.symmetric(
+          horizontal: 24 * scale,
+          vertical: 24 * scale,
+        ),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Padding(
+            padding: EdgeInsets.all(24 * scale),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  l10n.privacyPolicyTitle,
+                  textAlign: TextAlign.center,
+                  style: titleStyle,
+                ),
+                SizedBox(height: 16 * scale),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12 * scale),
+                    color: colors.surfaceVariant.withOpacity(
+                      theme.brightness == Brightness.dark ? 0.2 : 0.4,
+                    ),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12 * scale),
+                    child: SizedBox(
+                      height: contentHeight,
+                      child: FutureBuilder<String>(
+                        future: _loadPolicy(context),
+                        builder: (context, snapshot) {
+                          if (snapshot.connectionState ==
+                              ConnectionState.waiting) {
+                            return const Center(
+                              child: CircularProgressIndicator(),
+                            );
+                          }
+                          if (snapshot.hasError) {
+                            return Center(
+                              child: Padding(
+                                padding: EdgeInsets.all(16 * scale),
+                                child: Text(
+                                  l10n.privacyPolicyLoadError,
+                                  textAlign: TextAlign.center,
+                                  style: theme.textTheme.bodyMedium,
+                                ),
+                              ),
+                            );
+                          }
+                          final policy = snapshot.data ?? '';
+                          return Scrollbar(
+                            thumbVisibility: true,
+                            child: SingleChildScrollView(
+                              padding: EdgeInsets.all(16 * scale),
+                              child: SelectableText(
+                                policy,
+                                style: bodyStyle,
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(height: 24 * scale),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () => Navigator.of(context)
+                        .pop(requireAcceptance),
+                    child: Text(
+                      requireAcceptance
+                          ? l10n.privacyPolicyAccept
+                          : l10n.privacyPolicyClose,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ flutter:
   assets:
     - assets/data/names.json
     - assets/videos/intro.mp4
+    - assets/privacy_policy/privacy-policy.md
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- add a reusable privacy policy dialog backed by a bundled markdown asset and localized strings
- persist a privacy policy acceptance flag and gate the onboarding tutorial until consent is given
- add a settings entry to reopen the policy and register the asset in the Flutter bundle

## Testing
- flutter test *(fails: Flutter SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d40d426fe883269437142675cb4f6e