### PR TITLE
Add in-app privacy policy view

### DIFF
--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -152,8 +152,8 @@ class SettingsPage extends StatelessWidget {
             key: const ValueKey('settings-privacy-policy'),
             leading: Icon(Icons.privacy_tip_outlined, size: iconSize),
             title: Text(l10n.privacyPolicyTitle),
-            onTap: () async {
-              await openPrivacyPolicyLink(context);
+            onTap: () {
+              showPrivacyPolicyContent(context);
             },
           ),
           ],

--- a/lib/widgets/privacy_policy_dialog.dart
+++ b/lib/widgets/privacy_policy_dialog.dart
@@ -24,6 +24,147 @@ Future<void> openPrivacyPolicyLink(BuildContext context) async {
   }
 }
 
+Future<void> showPrivacyPolicyContent(BuildContext context) async {
+  final l10n = AppLocalizations.of(context)!;
+  final theme = Theme.of(context);
+  final scale = context.layoutScale;
+  final textTheme = theme.textTheme;
+  final sectionTitleStyle =
+      textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700);
+  final bodyStyle = textTheme.bodyMedium?.copyWith(height: 1.5);
+  final linkStyle = textTheme.bodyMedium?.copyWith(
+    color: Colors.blue,
+    decoration: TextDecoration.underline,
+    fontWeight: FontWeight.w600,
+  );
+
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) {
+      final maxHeight = MediaQuery.of(dialogContext).size.height * 0.7;
+
+      return AlertDialog(
+        title: const Text('Privacy Policy'),
+        contentPadding: EdgeInsets.only(
+          left: 24 * scale,
+          right: 16 * scale,
+          top: 16 * scale,
+          bottom: 0,
+        ),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxHeight),
+            child: Scrollbar(
+              child: SingleChildScrollView(
+                child: Padding(
+                  padding: EdgeInsets.only(right: 8 * scale),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Privacy Policy', style: sectionTitleStyle),
+                      SizedBox(height: 12 * scale),
+                      Text(
+                        'UzorPlay ("we", "our", "us") develops and publishes mobile games.\n'
+                        'This Privacy Policy explains how we handle information when you use our games.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('Information We Collect', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'We do not collect or store any personal data such as name, email, phone number, or contacts.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'Our games may display advertising provided by Google AdMob. In this case, Google may collect certain technical data '
+                        '(such as device identifiers or approximate location) in order to show relevant ads.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'Apart from advertising, all game progress and settings are stored only on your device and are not sent to us.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('How We Use Information', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'We do not use or process personal information.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'Advertising is managed directly by Google AdMob in accordance with their Privacy Policy.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('Data Sharing', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'We do not sell, trade, or transfer your data to third parties.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'Only Google AdMob may process data for the purpose of serving ads.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('Children’s Privacy', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'Our games are designed for a general audience. We do not knowingly collect personal information from children. '
+                        'Ads shown in our games are provided by Google and follow their family-friendly policies if enabled.',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('Changes to This Policy', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'We may update this Privacy Policy from time to time. Updates will be published at:\n'
+                        'https://uzorplay.github.io/privacy-policy',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      Text('Contact Us', style: sectionTitleStyle),
+                      SizedBox(height: 8 * scale),
+                      Text(
+                        'If you have questions about this Privacy Policy, you can contact us:\n'
+                        '📧 UzorPlay@gmail.com',
+                        style: bodyStyle,
+                      ),
+                      SizedBox(height: 16 * scale),
+                      InkWell(
+                        onTap: () => openPrivacyPolicyLink(dialogContext),
+                        borderRadius: BorderRadius.circular(8 * scale),
+                        child: Padding(
+                          padding: EdgeInsets.symmetric(vertical: 4 * scale),
+                          child: Text(
+                            '👉 Read full policy online',
+                            style: linkStyle,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(l10n.privacyPolicyClose),
+          ),
+        ],
+      );
+    },
+  );
+}
+
 Future<bool> showPrivacyPolicyDialog(
   BuildContext context, {
   required bool requireAcceptance,


### PR DESCRIPTION
## Summary
- add an in-app privacy policy dialog with formatted English content and external link
- update the settings privacy policy entry to open the new dialog

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4186e6ca48326ae66d8ed6c2bfe3c