### PR TITLE
Set medium font size as default selection

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -256,7 +256,7 @@ class AppState extends ChangeNotifier {
   static const double _baseFontSizeSp = 16.0;
   static const double minFontScale = minFontSizeSp / _baseFontSizeSp;
   static const double maxFontScale = maxFontSizeSp / _baseFontSizeSp;
-  double _fontScale = 1.0;
+  double _fontScale = mediumFontSizeSp / _baseFontSizeSp;
 
   Map<Difficulty, DifficultyStats> statsByDifficulty = _defaultStats();
 


### PR DESCRIPTION
## Summary
- default the stored font scale to the medium option so first launch uses the medium font size

## Testing
- flutter test *(fails: flutter is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d42f4a3f408326b885510a1bc47bf7