### PR TITLE
Adjust flag selection flow

### DIFF
--- a/lib/battle/flag_picker.dart
+++ b/lib/battle/flag_picker.dart
@@ -11,6 +11,7 @@ Future<String?> showFlagPicker(
   final l10n = AppLocalizations.of(context)!;
   return showModalBottomSheet<String>(
     context: context,
+    useRootNavigator: true,
     backgroundColor: theme.colorScheme.surface,
     isScrollControlled: true,
     shape: const RoundedRectangleBorder(


### PR DESCRIPTION
## Summary
- ensure the flag picker bottom sheet uses the root navigator so it floats above nested navigation stacks
- defer the flag selection prompt until after the first frame and guard against concurrent flows while waiting for the route to settle

## Testing
- `dart format lib/battle/flag_picker.dart lib/battle/battle_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d44710b528832692bf34a01326e645