### PR TITLE
Adjust daily challenge star goal to calendar days

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1894,7 +1894,7 @@ class _DailyChallengesTabState extends State<_DailyChallengesTab>
         final monthDays =
             DateUtils.getDaysInMonth(_visibleMonth.year, _visibleMonth.month);
         final progress = app.completedDailyCount(_visibleMonth);
-        const challengeGoal = 30;
+        final challengeGoal = monthDays;
         final headerProgress = progress.clamp(0, challengeGoal);
 
         final textScaleFactor = media.textScaleFactor;


### PR DESCRIPTION
## Summary
- compute the daily challenge target stars from the visible month's day count so the 0/X counter adjusts automatically

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e1afb1b08326b3532d2064a7460d