### PR TITLE
Show player's championship rank on home card

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -580,7 +580,7 @@ class _ChallengeCarousel extends StatelessWidget {
             score: vm.score,
             gradient: colors.championshipChallengeGradient,
             icon: Icons.workspace_premium_outlined,
-            badge: '2G',
+            badge: vm.rankLabel,
           );
         },
       ),
@@ -1121,13 +1121,18 @@ class _ChampionshipCard extends StatelessWidget {
 class _ChampionshipCardVm {
   const _ChampionshipCardVm({
     required this.score,
+    required this.rank,
   });
 
   final int score;
+  final int rank;
+
+  String get rankLabel => math.max(1, math.min(rank, 101)).toString();
 
   factory _ChampionshipCardVm.fromModel(ChampionshipModel model) {
     return _ChampionshipCardVm(
       score: model.myScore,
+      rank: model.myRank,
     );
   }
 
@@ -1136,11 +1141,13 @@ class _ChampionshipCardVm {
     if (identical(this, other)) {
       return true;
     }
-    return other is _ChampionshipCardVm && other.score == score;
+    return other is _ChampionshipCardVm &&
+        other.score == score &&
+        other.rank == rank;
   }
 
   @override
-  int get hashCode => score.hashCode;
+  int get hashCode => Object.hash(score, rank);
 }
 
 class _DailyChain extends StatelessWidget {


### PR DESCRIPTION
## Summary
- replace the static "2G" championship badge with the player's current rank
- expose the rank through the championship card view model with bounds enforcement
- ensure the home championship card rebuilds when rank updates so the badge stays current

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e59996e88326a9ec7cefbc5fd259