### PR TITLE
Implement combo badge toast system

### DIFF
--- a/assets/icons/combos/combo.svg
+++ b/assets/icons/combos/combo.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <circle cx="32" cy="32" r="28" fill="#FFD54F" opacity="0.8"/>
+    <path d="M32 14l5.18 11.75 12.82 1.1-9.7 8.62 2.84 12.53L32 40.6l-10.14 7.4 2.84-12.53-9.7-8.62 12.82-1.1z" fill="#F57C00"/>
+  </g>
+</svg>

--- a/assets/icons/combos/perfect.svg
+++ b/assets/icons/combos/perfect.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <circle cx="32" cy="32" r="28" fill="#C5E1A5"/>
+    <path d="M45.3 22.4c1.26 1.2 1.26 3.13 0 4.33L30.6 40.6c-1.26 1.2-3.3 1.2-4.56 0l-7.34-7a3 3 0 0 1 0-4.33 3.4 3.4 0 0 1 4.72 0l5.34 5.1 12.8-12.3a3.4 3.4 0 0 1 4.74 0z" fill="#2E7D32"/>
+  </g>
+</svg>

--- a/assets/icons/combos/speed.svg
+++ b/assets/icons/combos/speed.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <circle cx="32" cy="32" r="28" fill="#BBDEFB"/>
+    <path d="M30.5 11l-6 18h8l-7 24 18-27h-9l6-15z" fill="#1976D2"/>
+  </g>
+</svg>

--- a/assets/icons/combos/streak.svg
+++ b/assets/icons/combos/streak.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="50%" x2="50%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#FF8A65"/>
+      <stop offset="100%" stop-color="#D84315"/>
+    </linearGradient>
+  </defs>
+  <path d="M36 8c2.4 8.27-3.6 12.4-9 16 7.6-.53 13.4 5.33 13 12-.4 6.67-6.27 12-13.94 12C17.4 48 12 41.73 12 34c0-7.73 4.27-13.6 10-18 3.33-2.47 5.87-4.67 7-8 1 3.33 2.8 5.87 7 8z" fill="url(#a)" fill-rule="nonzero"/>
+</svg>

--- a/lib/combo/combo_controller.dart
+++ b/lib/combo/combo_controller.dart
@@ -1,0 +1,512 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../models.dart';
+import 'combo_theme.dart';
+import 'combo_toast.dart';
+
+abstract class ComboHost {
+  BuildContext get context;
+  TickerProvider get vsync;
+  double get fontScale;
+}
+
+enum _ToastType { combo, streak, perfectRow, perfectColumn, perfectBox, speed }
+
+class ComboController implements ComboEventSink {
+  ComboController({required this.host});
+
+  static const _comboIcon = 'assets/icons/combos/combo.svg';
+  static const _streakIcon = 'assets/icons/combos/streak.svg';
+  static const _perfectIcon = 'assets/icons/combos/perfect.svg';
+  static const _speedIcon = 'assets/icons/combos/speed.svg';
+
+  final ComboHost host;
+
+  bool _enabled = true;
+  bool _hapticsEnabled = true;
+
+  final Queue<_ToastRequest> _queue = Queue<_ToastRequest>();
+  final List<DateTime> _recentShows = <DateTime>[];
+  _ToastRequest? _activeToast;
+  OverlayEntry? _overlayEntry;
+  AnimationController? _controller;
+  Timer? _dismissTimer;
+  Timer? _throttleTimer;
+  bool _showing = false;
+  DateTime? _lastShowStarted;
+
+  int _comboCount = 0;
+  int _maxComboShown = 0;
+  DateTime? _lastComboTs;
+  Difficulty? _currentDifficulty;
+
+  int _noHintChain = 0;
+  int _lastStreakShown = 0;
+
+  @override
+  void updateSettings({required bool enabled, required bool hapticsEnabled}) {
+    _enabled = enabled;
+    _hapticsEnabled = hapticsEnabled;
+    if (!_enabled) {
+      reset();
+    }
+  }
+
+  @override
+  void onCellFilled({
+    required bool correct,
+    required int timestampMs,
+    Difficulty? difficulty,
+  }) {
+    _currentDifficulty = difficulty;
+    final ts = DateTime.fromMillisecondsSinceEpoch(timestampMs);
+    if (!correct) {
+      _comboCount = 0;
+      _lastComboTs = ts;
+      _maxComboShown = 0;
+      _noHintChain = 0;
+      _lastStreakShown = 0;
+      return;
+    }
+    final window = Duration(milliseconds: _comboWindowMs(difficulty));
+    if (_lastComboTs != null && ts.difference(_lastComboTs!) <= window) {
+      _comboCount++;
+    } else {
+      _comboCount = 1;
+      _maxComboShown = 1;
+    }
+    _lastComboTs = ts;
+
+    if (_comboCount >= 2) {
+      final l10n = AppLocalizations.of(host.context);
+      if (l10n == null) {
+        return;
+      }
+      final label = l10n.comboX(_comboCount);
+      _enqueueToast(
+        _ToastRequest(
+          type: _ToastType.combo,
+          label: label,
+          iconAsset: _comboIcon,
+          level: _comboCount,
+          difficulty: difficulty,
+        ),
+        allowUpgrade: true,
+      );
+      if (_comboCount > _maxComboShown) {
+        _maxComboShown = _comboCount;
+        _maybeHaptic();
+      }
+    }
+  }
+
+  @override
+  void onPerfectRow(Difficulty? difficulty) {
+    _emitPerfectToast(_ToastType.perfectRow, difficulty);
+  }
+
+  @override
+  void onPerfectColumn(Difficulty? difficulty) {
+    _emitPerfectToast(_ToastType.perfectColumn, difficulty);
+  }
+
+  @override
+  void onPerfectBox(Difficulty? difficulty) {
+    _emitPerfectToast(_ToastType.perfectBox, difficulty);
+  }
+
+  @override
+  void onNoHintStep(Difficulty? difficulty) {
+    _currentDifficulty = difficulty;
+    _noHintChain++;
+    final milestones = const [5, 10, 20];
+    for (final milestone in milestones) {
+      if (_noHintChain == milestone && _lastStreakShown < milestone) {
+        _lastStreakShown = milestone;
+        final l10n = AppLocalizations.of(host.context);
+        if (l10n == null) {
+          return;
+        }
+        final label = l10n.streakN(milestone);
+        _enqueueToast(
+          _ToastRequest(
+            type: _ToastType.streak,
+            label: label,
+            iconAsset: _streakIcon,
+            level: milestone,
+            difficulty: difficulty,
+          ),
+        );
+        break;
+      }
+    }
+  }
+
+  @override
+  void onHintUsed() {
+    _noHintChain = 0;
+    _lastStreakShown = 0;
+  }
+
+  @override
+  void onLevelFinished({
+    required Difficulty? difficulty,
+    required int durationMs,
+  }) {
+    _currentDifficulty = difficulty;
+    if (difficulty == null) {
+      return;
+    }
+    final threshold = _speedThresholdMs[difficulty];
+    if (threshold == null || durationMs > threshold) {
+      return;
+    }
+    final l10n = AppLocalizations.of(host.context);
+    if (l10n == null) {
+      return;
+    }
+    final seconds = (durationMs / 1000).round();
+    final label = l10n.speedBonus(secondsFormat(seconds));
+    _enqueueToast(
+      _ToastRequest(
+        type: _ToastType.speed,
+        label: label,
+        iconAsset: _speedIcon,
+        level: 0,
+        difficulty: difficulty,
+      ),
+    );
+  }
+
+  @override
+  void reset() {
+    _comboCount = 0;
+    _maxComboShown = 0;
+    _lastComboTs = null;
+    _noHintChain = 0;
+    _lastStreakShown = 0;
+    _queue.clear();
+    _dismissActive(immediate: true);
+  }
+
+  @override
+  void dispose() {
+    _dismissActive(immediate: true);
+    _throttleTimer?.cancel();
+  }
+
+  void _emitPerfectToast(_ToastType type, Difficulty? difficulty) {
+    final l10n = AppLocalizations.of(host.context);
+    if (l10n == null) {
+      return;
+    }
+    String label;
+    switch (type) {
+      case _ToastType.perfectRow:
+        label = l10n.perfectRow;
+        break;
+      case _ToastType.perfectColumn:
+        label = l10n.perfectCol;
+        break;
+      case _ToastType.perfectBox:
+        label = l10n.perfectBox;
+        break;
+      default:
+        label = '';
+    }
+    if (label.isEmpty) {
+      return;
+    }
+    _enqueueToast(
+      _ToastRequest(
+        type: type,
+        label: label,
+        iconAsset: _perfectIcon,
+        difficulty: difficulty,
+      ),
+    );
+  }
+
+  void _enqueueToast(
+    _ToastRequest request, {
+    bool allowUpgrade = false,
+  }) {
+    if (!_enabled) {
+      return;
+    }
+    final theme = Theme.of(host.context);
+    final comboTheme = theme.extension<ComboTheme>() ?? _fallbackTheme;
+    if (_activeToast != null &&
+        allowUpgrade &&
+        _activeToast!.type == request.type &&
+        request.level >= _activeToast!.level) {
+      _activeToast = request;
+      _overlayEntry?.markNeedsBuild();
+      return;
+    }
+    if (_queue.length >= comboTheme.maxQueue) {
+      _queue.removeFirst();
+    }
+    _queue.add(request);
+    _scheduleShow();
+  }
+
+  void _scheduleShow() {
+    if (_showing) {
+      return;
+    }
+    if (_activeToast != null) {
+      return;
+    }
+    if (_queue.isEmpty) {
+      return;
+    }
+    final now = DateTime.now();
+    final throttleMs = _effectiveThrottleMs();
+    if (_lastShowStarted != null) {
+      final elapsed = now.difference(_lastShowStarted!);
+      if (elapsed < Duration(milliseconds: throttleMs)) {
+        final delay = Duration(milliseconds: throttleMs) - elapsed;
+        _throttleTimer?.cancel();
+        _throttleTimer = Timer(delay, _scheduleShow);
+        return;
+      }
+    }
+    final canShow = _canShowNow(now);
+    if (!canShow) {
+      if (_recentShows.isNotEmpty) {
+        final earliest = _recentShows.first;
+        final retryAt = earliest.add(const Duration(seconds: 10));
+        final wait = retryAt.difference(now);
+        if (!wait.isNegative) {
+          _throttleTimer?.cancel();
+          _throttleTimer = Timer(wait, _scheduleShow);
+        }
+      }
+      return;
+    }
+    final request = _queue.removeFirst();
+    _showToast(request);
+  }
+
+  bool _canShowNow(DateTime now) {
+    _recentShows.removeWhere(
+      (date) => now.difference(date) > const Duration(seconds: 10),
+    );
+    if (_recentShows.length >= 6) {
+      return false;
+    }
+    return true;
+  }
+
+  Future<void> _showToast(_ToastRequest request) async {
+    final overlay = Overlay.of(host.context);
+    if (overlay == null) {
+      return;
+    }
+    final theme = Theme.of(host.context);
+    final comboTheme = theme.extension<ComboTheme>() ?? _fallbackTheme;
+    _showing = true;
+    _activeToast = request;
+    _lastShowStarted = DateTime.now();
+    _recentShows.add(_lastShowStarted!);
+
+    final media = MediaQuery.of(host.context);
+    final reduceMotion =
+        media.disableAnimations || media.accessibleNavigation;
+
+    _controller?.dispose();
+    _controller = AnimationController(
+      duration: reduceMotion
+          ? const Duration(milliseconds: 120)
+          : Duration(milliseconds: comboTheme.inMs),
+      reverseDuration: reduceMotion
+          ? const Duration(milliseconds: 120)
+          : Duration(milliseconds: comboTheme.outMs),
+      vsync: host.vsync,
+    );
+
+    if (_overlayEntry == null) {
+      _overlayEntry = OverlayEntry(
+        builder: (context) {
+          final payload = _activeToast;
+          if (payload == null) {
+            return const SizedBox.shrink();
+          }
+          final animation = CurvedAnimation(
+            parent: _controller!,
+            curve: Curves.easeOutCubic,
+            reverseCurve: Curves.easeInCubic,
+          );
+          final fade = animation;
+          final scaleTween = reduceMotion
+              ? const AlwaysStoppedAnimation<double>(1.0)
+              : Tween<double>(begin: 0.9, end: 1.0).animate(animation);
+          final offsetTween = reduceMotion
+              ? const AlwaysStoppedAnimation<Offset>(Offset.zero)
+              : Tween<Offset>(
+                  begin: Offset(0, comboTheme.offsetY / -56.0),
+                  end: Offset.zero,
+                ).animate(animation);
+          final safeTop = media.padding.top;
+          final maxWidth = math.min(media.size.width * 0.9, 360.0);
+          return Positioned(
+            top: safeTop + comboTheme.offsetY,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: FadeTransition(
+                  opacity: fade,
+                  child: SlideTransition(
+                    position: offsetTween,
+                    child: ScaleTransition(
+                      scale: scaleTween,
+                      child: ComboToast(
+                        message: payload.label,
+                        iconAsset: payload.iconAsset,
+                        fontScale: host.fontScale,
+                        maxWidth: maxWidth,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+      overlay.insert(_overlayEntry!);
+    } else {
+      _overlayEntry!.markNeedsBuild();
+    }
+
+    await _controller!.forward(from: 0);
+
+    _dismissTimer?.cancel();
+    _dismissTimer = Timer(
+      Duration(milliseconds: comboTheme.displayMs),
+      () => _dismissActive(),
+    );
+    _showing = false;
+  }
+
+  Future<void> _hideActive({bool immediate = false}) async {
+    _dismissTimer?.cancel();
+    _dismissTimer = null;
+    if (_controller == null || _overlayEntry == null) {
+      _activeToast = null;
+      _scheduleShow();
+      return;
+    }
+    if (immediate) {
+      _controller!.stop();
+      _controller!.dispose();
+      _controller = null;
+      _overlayEntry!.remove();
+      _overlayEntry = null;
+      _activeToast = null;
+      _scheduleShow();
+      return;
+    }
+    try {
+      await _controller!.reverse();
+    } catch (_) {}
+    _controller!.dispose();
+    _controller = null;
+    _overlayEntry!.remove();
+    _overlayEntry = null;
+    _activeToast = null;
+    _scheduleShow();
+  }
+
+  void _dismissActive({bool immediate = false}) {
+    unawaited(_hideActive(immediate: immediate));
+  }
+
+  int _comboWindowMs(Difficulty? difficulty) {
+    if (difficulty == null) {
+      return 1200;
+    }
+    switch (difficulty) {
+      case Difficulty.high:
+        return 1100;
+      case Difficulty.expert:
+      case Difficulty.master:
+        return 1000;
+      default:
+        return 1200;
+    }
+  }
+
+  int _effectiveThrottleMs() {
+    final theme = Theme.of(host.context);
+    final comboTheme = theme.extension<ComboTheme>() ?? _fallbackTheme;
+    final difficulty = _currentDifficulty;
+    if (difficulty == Difficulty.expert || difficulty == Difficulty.master) {
+      return comboTheme.throttleMs + 120;
+    }
+    if (difficulty == Difficulty.high) {
+      return comboTheme.throttleMs + 60;
+    }
+    return comboTheme.throttleMs;
+  }
+
+  void _maybeHaptic() {
+    if (!_hapticsEnabled) {
+      return;
+    }
+    HapticFeedback.selectionClick();
+  }
+
+  static const _fallbackTheme = ComboTheme(
+    tintStrength: 0.1,
+    maxQueue: 5,
+    throttleMs: 800,
+    inMs: 200,
+    outMs: 200,
+    offsetY: 10,
+    baseHeight: 56,
+    displayMs: 1000,
+    elevation: 2,
+    containerOpacity: 0.85,
+    outlineOpacity: 0.24,
+  );
+
+  static const Map<Difficulty, int> _speedThresholdMs = {
+    Difficulty.novice: 8 * 60 * 1000,
+    Difficulty.medium: 7 * 60 * 1000,
+    Difficulty.high: 6 * 60 * 1000,
+    Difficulty.expert: 5 * 60 * 1000,
+    Difficulty.master: 4 * 60 * 1000,
+  };
+
+  String secondsFormat(int totalSeconds) {
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+  }
+}
+
+class _ToastRequest {
+  final _ToastType type;
+  final String label;
+  final String iconAsset;
+  final int level;
+  final Difficulty? difficulty;
+
+  const _ToastRequest({
+    required this.type,
+    required this.label,
+    required this.iconAsset,
+    this.level = 0,
+    this.difficulty,
+  });
+}

--- a/lib/combo/combo_theme.dart
+++ b/lib/combo/combo_theme.dart
@@ -1,0 +1,97 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// Theme settings for combo toasts.
+class ComboTheme extends ThemeExtension<ComboTheme> {
+  final double tintStrength;
+  final int maxQueue;
+  final int throttleMs;
+  final int inMs;
+  final int outMs;
+  final double offsetY;
+  final double baseHeight;
+  final int displayMs;
+  final double elevation;
+  final double containerOpacity;
+  final double outlineOpacity;
+
+  const ComboTheme({
+    required this.tintStrength,
+    required this.maxQueue,
+    required this.throttleMs,
+    required this.inMs,
+    required this.outMs,
+    required this.offsetY,
+    required this.baseHeight,
+    required this.displayMs,
+    required this.elevation,
+    required this.containerOpacity,
+    required this.outlineOpacity,
+  });
+
+  @override
+  ComboTheme copyWith({
+    double? tintStrength,
+    int? maxQueue,
+    int? throttleMs,
+    int? inMs,
+    int? outMs,
+    double? offsetY,
+    double? baseHeight,
+    int? displayMs,
+    double? elevation,
+    double? containerOpacity,
+    double? outlineOpacity,
+  }) {
+    return ComboTheme(
+      tintStrength: tintStrength ?? this.tintStrength,
+      maxQueue: maxQueue ?? this.maxQueue,
+      throttleMs: throttleMs ?? this.throttleMs,
+      inMs: inMs ?? this.inMs,
+      outMs: outMs ?? this.outMs,
+      offsetY: offsetY ?? this.offsetY,
+      baseHeight: baseHeight ?? this.baseHeight,
+      displayMs: displayMs ?? this.displayMs,
+      elevation: elevation ?? this.elevation,
+      containerOpacity: containerOpacity ?? this.containerOpacity,
+      outlineOpacity: outlineOpacity ?? this.outlineOpacity,
+    );
+  }
+
+  @override
+  ComboTheme lerp(ThemeExtension<ComboTheme>? other, double t) {
+    if (other is! ComboTheme) {
+      return this;
+    }
+    return ComboTheme(
+      tintStrength:
+          ui.lerpDouble(tintStrength, other.tintStrength, t) ?? tintStrength,
+      maxQueue: ui
+              .lerpDouble(maxQueue.toDouble(), other.maxQueue.toDouble(), t)
+              ?.round() ??
+          maxQueue,
+      throttleMs: ui
+              .lerpDouble(throttleMs.toDouble(), other.throttleMs.toDouble(), t)
+              ?.round() ??
+          throttleMs,
+      inMs: ui.lerpDouble(inMs.toDouble(), other.inMs.toDouble(), t)?.round() ?? inMs,
+      outMs: ui
+              .lerpDouble(outMs.toDouble(), other.outMs.toDouble(), t)
+              ?.round() ??
+          outMs,
+      offsetY: ui.lerpDouble(offsetY, other.offsetY, t) ?? offsetY,
+      baseHeight: ui.lerpDouble(baseHeight, other.baseHeight, t) ?? baseHeight,
+      displayMs: ui
+              .lerpDouble(displayMs.toDouble(), other.displayMs.toDouble(), t)
+              ?.round() ??
+          displayMs,
+      elevation: ui.lerpDouble(elevation, other.elevation, t) ?? elevation,
+      containerOpacity: ui
+              .lerpDouble(containerOpacity, other.containerOpacity, t) ??
+          containerOpacity,
+      outlineOpacity: ui
+              .lerpDouble(outlineOpacity, other.outlineOpacity, t) ?? outlineOpacity,
+    );
+  }
+}

--- a/lib/combo/combo_toast.dart
+++ b/lib/combo/combo_toast.dart
@@ -1,0 +1,105 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import 'combo_theme.dart';
+
+class ComboToast extends StatelessWidget {
+  final String message;
+  final String iconAsset;
+  final double fontScale;
+  final double maxWidth;
+
+  const ComboToast({
+    super.key,
+    required this.message,
+    required this.iconAsset,
+    required this.fontScale,
+    required this.maxWidth,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final comboTheme = theme.extension<ComboTheme>() ??
+        const ComboTheme(
+          tintStrength: 0.1,
+          maxQueue: 5,
+          throttleMs: 800,
+          inMs: 200,
+          outMs: 200,
+          offsetY: 10,
+          baseHeight: 56,
+          displayMs: 1000,
+          elevation: 2,
+          containerOpacity: 0.85,
+          outlineOpacity: 0.24,
+        );
+    final scheme = theme.colorScheme;
+    final background = Color.alphaBlend(
+      scheme.primary.withOpacity(comboTheme.tintStrength),
+      scheme.surface,
+    ).withOpacity(comboTheme.containerOpacity);
+    final borderColor = scheme.onSurface.withOpacity(comboTheme.outlineOpacity);
+    final onSurface = scheme.onSurface.withOpacity(0.8);
+    final baseStyle = theme.textTheme.bodyMedium ??
+        const TextStyle(fontSize: 16, fontWeight: FontWeight.w600);
+    final resolvedFontSize = (baseStyle.fontSize ?? 16) * fontScale;
+    final textStyle = baseStyle.copyWith(
+      fontSize: resolvedFontSize,
+      fontWeight: FontWeight.w600,
+      color: onSurface,
+    );
+    final shape = theme.cardTheme.shape;
+    BorderRadius borderRadius;
+    if (shape is RoundedRectangleBorder) {
+      borderRadius = shape.borderRadius.resolve(Directionality.of(context));
+    } else {
+      borderRadius = BorderRadius.circular(14);
+    }
+
+    final constrainedWidth = math.min(360.0, maxWidth);
+    final resolvedHeight = math.max(comboTheme.baseHeight, resolvedFontSize * 2.8);
+
+    return RepaintBoundary(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: constrainedWidth),
+        child: Material(
+          elevation: comboTheme.elevation,
+          color: background,
+          shadowColor: scheme.shadow.withOpacity(0.3),
+          shape: RoundedRectangleBorder(
+            borderRadius: borderRadius,
+            side: BorderSide(color: borderColor, width: 2),
+          ),
+          child: Container(
+            height: resolvedHeight,
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            alignment: Alignment.center,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SvgPicture.asset(
+                  iconAsset,
+                  width: 28,
+                  height: 28,
+                  colorFilter: ColorFilter.mode(onSurface, BlendMode.srcIn),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    message,
+                    style: textStyle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Sudoku",
+  "combo_x": "Combo ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Serie {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Perfekte Zeile",
+  "perfect_col": "Perfekte Spalte",
+  "perfect_box": "Perfekter Block",
+  "speed_bonus": "Tempo-Bonus {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "Kein aktives Spiel. Kehre zum Startbildschirm zurück.",
   "victoryTitle": "Glückwunsch!",
   "victoryMessage": "Rätsel gelöst in {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Sound & Musik",
   "soundsEffectsLabel": "Soundeffekte",
   "vibrationLabel": "Vibration",
+  "comboBadgesLabel": "Combo-Badges",
+  "comboHapticsLabel": "Badge-Haptik",
   "miscSectionTitle": "Sonstiges",
   "howToPlayTitle": "So spielst du",
   "howToPlayRowRule": "In jeder Zeile stehen die Ziffern 1 bis 9 ohne Wiederholung",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -182,6 +182,33 @@
     }
   },
   "gameScreenTitle": "Sudoku",
+  "combo_x": "Combo ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Streak {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Perfect Row",
+  "perfect_col": "Perfect Column",
+  "perfect_box": "Perfect Box",
+  "speed_bonus": "Speed Bonus {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "No active game. Return to the home screen.",
   "victoryTitle": "Congratulations!",
   "victoryMessage": "Puzzle solved in {time}.",
@@ -215,6 +242,8 @@
   "audioSectionTitle": "Sound & music",
   "soundsEffectsLabel": "Sound effects",
   "vibrationLabel": "Vibration",
+  "comboBadgesLabel": "Combo badges",
+  "comboHapticsLabel": "Badge haptics",
   "miscSectionTitle": "Other",
   "howToPlayTitle": "How to play",
   "howToPlayRowRule": "Each row has the digits 1 to 9 with no repeats",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Sudoku",
+  "combo_x": "Combo ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Racha {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Fila perfecta",
+  "perfect_col": "Columna perfecta",
+  "perfect_box": "Cuadro perfecto",
+  "speed_bonus": "Bonificación de velocidad {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "No hay juego activo. Regrese a la pantalla de inicio.",
   "victoryTitle": "¡Felicidades!",
   "victoryMessage": "Rompecabezas resuelto en {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Sonido y música",
   "soundsEffectsLabel": "Efectos sonoros",
   "vibrationLabel": "Vibración",
+  "comboBadgesLabel": "Insignias de combo",
+  "comboHapticsLabel": "Háptica de insignias",
   "miscSectionTitle": "Otro",
   "howToPlayTitle": "Cómo jugar",
   "howToPlayRowRule": "Cada fila tiene los números del 1 al 9 sin repetir",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Sudoku",
+  "combo_x": "Combo ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Série {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Ligne parfaite",
+  "perfect_col": "Colonne parfaite",
+  "perfect_box": "Bloc parfait",
+  "speed_bonus": "Bonus de vitesse {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "Aucune partie en cours. Revenez à l'écran d'accueil.",
   "victoryTitle": "Félicitations !",
   "victoryMessage": "Énigme résolue en {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Son & musique",
   "soundsEffectsLabel": "Effets sonores",
   "vibrationLabel": "Vibration",
+  "comboBadgesLabel": "Badges combo",
+  "comboHapticsLabel": "Retour haptique des badges",
   "miscSectionTitle": "Autre",
   "howToPlayTitle": "Comment jouer",
   "howToPlayRowRule": "Chaque ligne contient les chiffres de 1 à 9 sans doublons",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "सुडोकू",
+  "combo_x": "कॉम्बो ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "स्ट्रिक {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "परफ़ेक्ट पंक्ति",
+  "perfect_col": "परफ़ेक्ट स्तंभ",
+  "perfect_box": "परफ़ेक्ट बॉक्स",
+  "speed_bonus": "स्पीड बोनस {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "कोई सक्रिय खेल नहीं। होम स्क्रीन पर लौटें।",
   "victoryTitle": "बधाई!",
   "victoryMessage": "{time} में पहेली हल हुई।",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "ध्वनि और संगीत",
   "soundsEffectsLabel": "ध्वनि प्रभाव",
   "vibrationLabel": "कंपन",
+  "comboBadgesLabel": "कॉम्बो बैज",
+  "comboHapticsLabel": "बैज हैप्टिक्स",
   "miscSectionTitle": "अन्य",
   "howToPlayTitle": "कैसे खेलें",
   "howToPlayRowRule": "हर पंक्ति में 1 से 9 तक अंक बिना दोहराव के होने चाहिए",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Sudoku",
+  "combo_x": "Combo ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Serie {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Riga perfetta",
+  "perfect_col": "Colonna perfetta",
+  "perfect_box": "Box perfetto",
+  "speed_bonus": "Bonus velocità {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "Nessun gioco attivo. Torna alla schermata principale.",
   "victoryTitle": "Congratulazioni!",
   "victoryMessage": "Schema risolto in {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Suono e musica",
   "soundsEffectsLabel": "Effetti sonori",
   "vibrationLabel": "Vibrazione",
+  "comboBadgesLabel": "Badge combo",
+  "comboHapticsLabel": "Feedback aptico badge",
   "miscSectionTitle": "Altro",
   "howToPlayTitle": "Come si gioca",
   "howToPlayRowRule": "Ogni riga contiene i numeri da 1 a 9 senza ripetizioni",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "数独",
+  "combo_x": "コンボ ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "ストリーク {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "パーフェクト行",
+  "perfect_col": "パーフェクト列",
+  "perfect_box": "パーフェクトブロック",
+  "speed_bonus": "スピードボーナス {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "アクティブなゲームはありません。ホーム画面に戻ります。",
   "victoryTitle": "おめでとう！",
   "victoryMessage": "パズルを {time} で解きました。",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "サウンドと音楽",
   "soundsEffectsLabel": "効果音",
   "vibrationLabel": "振動",
+  "comboBadgesLabel": "コンボバッジ",
+  "comboHapticsLabel": "バッジの触覚フィードバック",
   "miscSectionTitle": "他の",
   "howToPlayTitle": "遊び方",
   "howToPlayRowRule": "各行には1〜9の数字を重複なく入れます",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "სუდოკუ",
+  "combo_x": "კომბო ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "სერია {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "სრულყოფილი რიგი",
+  "perfect_col": "სრულყოფილი სვეტი",
+  "perfect_box": "სრულყოფილი ბლოკი",
+  "speed_bonus": "სისწრაფის ბონუსი {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "აქტიური თამაში არ არის. დაბრუნდით მთავარ ეკრანზე.",
   "victoryTitle": "გილოცავთ!",
   "victoryMessage": "თავსატეხი ამოხსნილია {time}-ში.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "ხმა და მუსიკა",
   "soundsEffectsLabel": "ხმის ეფექტები",
   "vibrationLabel": "ვიბრაცია",
+  "comboBadgesLabel": "კომბო ბეჯები",
+  "comboHapticsLabel": "ბეჯების ჰაპტიკა",
   "miscSectionTitle": "სხვა",
   "howToPlayTitle": "როგორ ვითამაშოთ",
   "howToPlayRowRule": "ყოველ რიგში უნდა იყოს ციფრები 1-დან 9-მდე გამეორებების გარეშე",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "스도쿠",
+  "combo_x": "콤보 ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "연속 {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "완벽한 행",
+  "perfect_col": "완벽한 열",
+  "perfect_box": "완벽한 박스",
+  "speed_bonus": "속도 보너스 {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "능동적 인 게임이 없습니다. 홈 화면으로 돌아갑니다.",
   "victoryTitle": "축하해요!",
   "victoryMessage": "퍼즐을 {time}에 해결했습니다.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "소리와 음악",
   "soundsEffectsLabel": "음향 효과",
   "vibrationLabel": "진동",
+  "comboBadgesLabel": "콤보 배지",
+  "comboHapticsLabel": "배지 햅틱",
   "miscSectionTitle": "다른",
   "howToPlayTitle": "플레이 방법",
   "howToPlayRowRule": "각 가로줄에는 1부터 9까지 숫자가 중복 없이 들어갑니다",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Судоку",
+  "combo_x": "Комбо ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Серия {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Идеальная строка",
+  "perfect_col": "Идеальный столбец",
+  "perfect_box": "Идеальный блок",
+  "speed_bonus": "Бонус скорости {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "Нет активной игры. Вернитесь на главный экран.",
   "victoryTitle": "Поздравляем!",
   "victoryMessage": "Головоломка решена за {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Звук и музыка",
   "soundsEffectsLabel": "Звуковые эффекты",
   "vibrationLabel": "Вибрация",
+  "comboBadgesLabel": "Бейджи комбо",
+  "comboHapticsLabel": "Вибрация бейджей",
   "miscSectionTitle": "Другое",
   "howToPlayTitle": "Как играть",
   "howToPlayRowRule": "В каждой строке цифры от 1 до 9 без повторов",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "Судоку",
+  "combo_x": "Комбо ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "Серія {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "Ідеальний рядок",
+  "perfect_col": "Ідеальний стовпець",
+  "perfect_box": "Ідеальний блок",
+  "speed_bonus": "Бонус швидкості {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "Немає активної гри. Поверніться на головний екран.",
   "victoryTitle": "Вітаємо!",
   "victoryMessage": "Головоломку розв'язано за {time}.",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "Звуки та музика",
   "soundsEffectsLabel": "Звукові ефекти",
   "vibrationLabel": "Вібрація",
+  "comboBadgesLabel": "Значки комбо",
+  "comboHapticsLabel": "Вібрація значків",
   "miscSectionTitle": "Інше",
   "howToPlayTitle": "Як грати",
   "howToPlayRowRule": "У кожному рядку цифри від 1 до 9 без повторів",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -181,6 +181,33 @@
     }
   },
   "gameScreenTitle": "数独",
+  "combo_x": "连击 ×{count}",
+  "@combo_x": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streak_n": "连胜 {count}",
+  "@streak_n": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "perfect_row": "完美行",
+  "perfect_col": "完美列",
+  "perfect_box": "完美宫",
+  "speed_bonus": "极速奖励 {time}",
+  "@speed_bonus": {
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
   "noActiveGameMessage": "没有进行中的游戏。返回主界面。",
   "victoryTitle": "恭喜！",
   "victoryMessage": "在 {time} 内完成谜题。",
@@ -214,6 +241,8 @@
   "audioSectionTitle": "声音与音乐",
   "soundsEffectsLabel": "音效",
   "vibrationLabel": "震动",
+  "comboBadgesLabel": "连击徽章",
+  "comboHapticsLabel": "徽章触感反馈",
   "miscSectionTitle": "其他",
   "howToPlayTitle": "怎么玩",
   "howToPlayRowRule": "每一行都要填上1到9且不重复",

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -103,6 +103,21 @@ class SettingsPage extends StatelessWidget {
             secondary: Icon(Icons.vibration, size: iconSize),
           ),
           SwitchListTile(
+            key: const ValueKey('settings-combo-badges'),
+            title: Text(l10n.comboBadgesLabel),
+            value: app.comboBadgesEnabled,
+            onChanged: (v) => app.toggleComboBadges(v),
+            secondary: Icon(Icons.stars_outlined, size: iconSize),
+          ),
+          SwitchListTile(
+            key: const ValueKey('settings-combo-haptics'),
+            title: Text(l10n.comboHapticsLabel),
+            value: app.comboHapticsEnabled,
+            onChanged:
+                app.comboBadgesEnabled ? (v) => app.toggleComboHaptics(v) : null,
+            secondary: Icon(Icons.touch_app_outlined, size: iconSize),
+          ),
+          SwitchListTile(
             key: const ValueKey('settings-champ-auto-scroll'),
             title: Text(l10n.championshipAutoScroll),
             value: championship.autoScrollEnabled,

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:sudoku2/flutter_gen/gen_l10n/app_localizations.dart';
 
+import 'combo/combo_theme.dart';
+
 /// Список доступных цветовых тем приложения.
 enum SudokuTheme { white, cream, green, black }
 
@@ -542,6 +544,61 @@ final Map<SudokuTheme, _ThemeConfig> _themeConfigs = {
   ),
 };
 
+final Map<SudokuTheme, ComboTheme> _comboThemes = {
+  SudokuTheme.white: const ComboTheme(
+    tintStrength: 0.1,
+    maxQueue: 5,
+    throttleMs: 800,
+    inMs: 200,
+    outMs: 200,
+    offsetY: 10,
+    baseHeight: 56,
+    displayMs: 1000,
+    elevation: 2,
+    containerOpacity: 0.85,
+    outlineOpacity: 0.24,
+  ),
+  SudokuTheme.cream: const ComboTheme(
+    tintStrength: 0.09,
+    maxQueue: 5,
+    throttleMs: 820,
+    inMs: 200,
+    outMs: 200,
+    offsetY: 10,
+    baseHeight: 56,
+    displayMs: 1000,
+    elevation: 2,
+    containerOpacity: 0.86,
+    outlineOpacity: 0.24,
+  ),
+  SudokuTheme.green: const ComboTheme(
+    tintStrength: 0.1,
+    maxQueue: 5,
+    throttleMs: 850,
+    inMs: 200,
+    outMs: 200,
+    offsetY: 10,
+    baseHeight: 56,
+    displayMs: 1000,
+    elevation: 2,
+    containerOpacity: 0.85,
+    outlineOpacity: 0.24,
+  ),
+  SudokuTheme.black: const ComboTheme(
+    tintStrength: 0.12,
+    maxQueue: 5,
+    throttleMs: 900,
+    inMs: 200,
+    outMs: 200,
+    offsetY: 10,
+    baseHeight: 58,
+    displayMs: 1000,
+    elevation: 1,
+    containerOpacity: 0.86,
+    outlineOpacity: 0.32,
+  ),
+};
+
 final Map<SudokuTheme, ThemeData> _themeCache = {};
 
 ThemeData buildSudokuTheme(SudokuTheme theme) {
@@ -643,7 +700,10 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
         thumbColor: config.primary,
         overlayColor: config.primary.withOpacity(0.12),
       ),
-      extensions: [config.colors],
+      extensions: [
+        config.colors,
+        _comboThemes[theme]!,
+      ],
     );
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_svg: ^2.0.10+1
   flutter_localizations:
     sdk: flutter
   provider: ^6.1.5+1
@@ -69,6 +70,7 @@ flutter:
   assets:
     - assets/data/names.json
     - assets/videos/intro.mp4
+    - assets/icons/combos/
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- add a combo toast controller, theme extension, and SVG assets for new badge overlays
- integrate combo logic/events into the game model and display settings
- localize badge strings and register flutter_svg plus asset directory

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6f4e21ba48326b582045d629c0be9