### PR TITLE
Add combo badge localization strings

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Combo x{count}",
+  "@comboX": {
+    "description": "Combo-Multiplikator-Abzeichen",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Serie {count}",
+  "@streakN": {
+    "description": "Abzeichen für Siegesserie",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Tempo-Bonus ({time})",
+  "@speedBonus": {
+    "description": "Belohnung für schnelleres Abschließen als das Ziel",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Perfekte Zeile",
+  "perfectCol": "Perfekte Spalte",
+  "perfectBox": "Perfekter Block",
   "noActiveGameMessage": "Kein aktives Spiel. Kehre zum Startbildschirm zurück.",
   "victoryTitle": "Glückwunsch!",
   "victoryMessage": "Rätsel gelöst in {time}.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -209,6 +209,36 @@
       }
     }
   },
+  "comboX": "Combo x{count}",
+  "@comboX": {
+    "description": "Combo multiplier badge",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Streak {count}",
+  "@streakN": {
+    "description": "Streak badge",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Speed Bonus ({time})",
+  "@speedBonus": {
+    "description": "Award for finishing faster than target",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Perfect Row",
+  "perfectCol": "Perfect Column",
+  "perfectBox": "Perfect Box",
   "noActiveGameMessage": "No active game. Return to the home screen.",
   "victoryTitle": "Congratulations!",
   "victoryMessage": "Puzzle solved in {time}.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Combo x{count}",
+  "@comboX": {
+    "description": "Insignia de multiplicador de combo",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Racha {count}",
+  "@streakN": {
+    "description": "Insignia de racha",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Bonificación de velocidad ({time})",
+  "@speedBonus": {
+    "description": "Premio por terminar antes del objetivo",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Fila perfecta",
+  "perfectCol": "Columna perfecta",
+  "perfectBox": "Cuadro perfecto",
   "noActiveGameMessage": "No hay juego activo. Regrese a la pantalla de inicio.",
   "victoryTitle": "¡Felicidades!",
   "victoryMessage": "Rompecabezas resuelto en {time}.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Combo x{count}",
+  "@comboX": {
+    "description": "Badge de multiplicateur de combo",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Série {count}",
+  "@streakN": {
+    "description": "Badge de série",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Bonus de vitesse ({time})",
+  "@speedBonus": {
+    "description": "Récompense pour avoir terminé plus vite que l'objectif",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Ligne parfaite",
+  "perfectCol": "Colonne parfaite",
+  "perfectBox": "Bloc parfait",
   "noActiveGameMessage": "Aucune partie en cours. Revenez à l'écran d'accueil.",
   "victoryTitle": "Félicitations !",
   "victoryMessage": "Énigme résolue en {time}.",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "कॉम्बो x{count}",
+  "@comboX": {
+    "description": "कॉम्बो गुणक बैज",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "स्ट्रिक {count}",
+  "@streakN": {
+    "description": "स्ट्रिक बैज",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "स्पीड बोनस ({time})",
+  "@speedBonus": {
+    "description": "लक्ष्य से तेज़ समाप्त करने पर पुरस्कार",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "परफ़ेक्ट पंक्ति",
+  "perfectCol": "परफ़ेक्ट स्तंभ",
+  "perfectBox": "परफ़ेक्ट बॉक्स",
   "noActiveGameMessage": "कोई सक्रिय खेल नहीं। होम स्क्रीन पर लौटें।",
   "victoryTitle": "बधाई!",
   "victoryMessage": "{time} में पहेली हल हुई।",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Combo x{count}",
+  "@comboX": {
+    "description": "Badge moltiplicatore combo",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Serie {count}",
+  "@streakN": {
+    "description": "Badge serie",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Bonus velocità ({time})",
+  "@speedBonus": {
+    "description": "Ricompensa per aver terminato prima dell'obiettivo",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Riga perfetta",
+  "perfectCol": "Colonna perfetta",
+  "perfectBox": "Box perfetto",
   "noActiveGameMessage": "Nessun gioco attivo. Torna alla schermata principale.",
   "victoryTitle": "Congratulazioni!",
   "victoryMessage": "Schema risolto in {time}.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "コンボ x{count}",
+  "@comboX": {
+    "description": "コンボ倍率バッジ",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "ストリーク {count}",
+  "@streakN": {
+    "description": "連勝バッジ",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "スピードボーナス ({time})",
+  "@speedBonus": {
+    "description": "目標より速くクリアした報酬",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "パーフェクト行",
+  "perfectCol": "パーフェクト列",
+  "perfectBox": "パーフェクトブロック",
   "noActiveGameMessage": "アクティブなゲームはありません。ホーム画面に戻ります。",
   "victoryTitle": "おめでとう！",
   "victoryMessage": "パズルを {time} で解きました。",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "კომბო x{count}",
+  "@comboX": {
+    "description": "კომბოს გამამრავლებელი ბეჯი",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "სერია {count}",
+  "@streakN": {
+    "description": "სერიის ბეჯი",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "სისწრაფის ბონუსი ({time})",
+  "@speedBonus": {
+    "description": "ჯილდო მიზნამდე უფრო სწრაფად დასრულებისთვის",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "სრულყოფილი რიგი",
+  "perfectCol": "სრულყოფილი სვეტი",
+  "perfectBox": "სრულყოფილი ბლოკი",
   "noActiveGameMessage": "აქტიური თამაში არ არის. დაბრუნდით მთავარ ეკრანზე.",
   "victoryTitle": "გილოცავთ!",
   "victoryMessage": "თავსატეხი ამოხსნილია {time}-ში.",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "콤보 x{count}",
+  "@comboX": {
+    "description": "콤보 배수 배지",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "연속 {count}",
+  "@streakN": {
+    "description": "연속 기록 배지",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "속도 보너스 ({time})",
+  "@speedBonus": {
+    "description": "목표보다 빨리 완료했을 때의 보상",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "완벽한 행",
+  "perfectCol": "완벽한 열",
+  "perfectBox": "완벽한 박스",
   "noActiveGameMessage": "능동적 인 게임이 없습니다. 홈 화면으로 돌아갑니다.",
   "victoryTitle": "축하해요!",
   "victoryMessage": "퍼즐을 {time}에 해결했습니다.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Комбо x{count}",
+  "@comboX": {
+    "description": "Значок множителя комбо",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Серия {count}",
+  "@streakN": {
+    "description": "Значок серии побед",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Бонус скорости ({time})",
+  "@speedBonus": {
+    "description": "Награда за прохождение быстрее цели",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Идеальная строка",
+  "perfectCol": "Идеальный столбец",
+  "perfectBox": "Идеальный блок",
   "noActiveGameMessage": "Нет активной игры. Вернитесь на главный экран.",
   "victoryTitle": "Поздравляем!",
   "victoryMessage": "Головоломка решена за {time}.",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "Комбо x{count}",
+  "@comboX": {
+    "description": "Значок множника комбо",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "Серія {count}",
+  "@streakN": {
+    "description": "Значок серії",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "Бонус швидкості ({time})",
+  "@speedBonus": {
+    "description": "Нагорода за проходження швидше за ціль",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "Ідеальний рядок",
+  "perfectCol": "Ідеальний стовпець",
+  "perfectBox": "Ідеальний блок",
   "noActiveGameMessage": "Немає активної гри. Поверніться на головний екран.",
   "victoryTitle": "Вітаємо!",
   "victoryMessage": "Головоломку розв'язано за {time}.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -208,6 +208,36 @@
       }
     }
   },
+  "comboX": "连击 x{count}",
+  "@comboX": {
+    "description": "连击倍率徽章",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "streakN": "连胜 {count}",
+  "@streakN": {
+    "description": "连胜徽章",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "speedBonus": "极速奖励 ({time})",
+  "@speedBonus": {
+    "description": "比目标更快完成的奖励",
+    "placeholders": {
+      "time": {
+        "type": "String"
+      }
+    }
+  },
+  "perfectRow": "完美行",
+  "perfectCol": "完美列",
+  "perfectBox": "完美宫",
   "noActiveGameMessage": "没有进行中的游戏。返回主界面。",
   "victoryTitle": "恭喜！",
   "victoryMessage": "在 {time} 内完成谜题。",


### PR DESCRIPTION
## Summary
- add combo, streak, speed bonus, and perfect badge strings to every locale
- include placeholder metadata required by the localization generator

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6fcddfa448326baeaf0258cb82618