### PR TITLE
Increase crosshair and block highlight opacity

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -269,10 +269,14 @@ class _BoardCell extends StatelessWidget {
         final selectedBackground = colors.selectedCell;
         final sameNumberBackground =
             Color.alphaBlend(colors.sameNumberCell, baseInner);
-        final blockBackground =
-            Color.alphaBlend(colors.blockHighlight, baseInner);
-        final crosshairBackground =
-            Color.alphaBlend(colors.crosshairHighlight, baseInner);
+        final blockBackground = Color.alphaBlend(
+          _increaseHighlightOpacity(colors.blockHighlight),
+          baseInner,
+        );
+        final crosshairBackground = Color.alphaBlend(
+          _increaseHighlightOpacity(colors.crosshairHighlight),
+          baseInner,
+        );
         final backgroundColor = cell.isSelected
             ? selectedBackground
             : highlightSameValue
@@ -353,4 +357,9 @@ class _CellState {
         incorrect,
         fontScale,
       );
+}
+
+Color _increaseHighlightOpacity(Color color) {
+  final increasedOpacity = (color.opacity * 1.1).clamp(0.0, 1.0);
+  return color.withOpacity(increasedOpacity);
 }


### PR DESCRIPTION
## Summary
- boost the opacity of the row/column crosshair and block highlights by 10%
- reuse existing theme colors while adjusting opacity dynamically during rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d840ac92388326a7ad0795c372dee8