### PR TITLE
Increase Sudoku board highlight opacity

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -360,6 +360,6 @@ class _CellState {
 }
 
 Color _increaseHighlightOpacity(Color color) {
-  final increasedOpacity = (color.opacity * 1.1).clamp(0.0, 1.0);
+  final increasedOpacity = (color.opacity * 1.21).clamp(0.0, 1.0);
   return color.withOpacity(increasedOpacity);
 }


### PR DESCRIPTION
## Summary
- scale the block and crosshair highlight opacity by an additional 10% to make the selection surroundings more pronounced

## Testing
- Unable to run tests (flutter command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8464adc00832695a581eb9712841a