### PR TITLE
Revert highlight opacity adjustments

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -269,14 +269,10 @@ class _BoardCell extends StatelessWidget {
         final selectedBackground = colors.selectedCell;
         final sameNumberBackground =
             Color.alphaBlend(colors.sameNumberCell, baseInner);
-        final blockBackground = Color.alphaBlend(
-          _increaseHighlightOpacity(colors.blockHighlight),
-          baseInner,
-        );
-        final crosshairBackground = Color.alphaBlend(
-          _increaseHighlightOpacity(colors.crosshairHighlight),
-          baseInner,
-        );
+        final blockBackground =
+            Color.alphaBlend(colors.blockHighlight, baseInner);
+        final crosshairBackground =
+            Color.alphaBlend(colors.crosshairHighlight, baseInner);
         final backgroundColor = cell.isSelected
             ? selectedBackground
             : highlightSameValue
@@ -357,9 +353,4 @@ class _CellState {
         incorrect,
         fontScale,
       );
-}
-
-Color _increaseHighlightOpacity(Color color) {
-  final increasedOpacity = (color.opacity * 1.21).clamp(0.0, 1.0);
-  return color.withOpacity(increasedOpacity);
 }


### PR DESCRIPTION
## Summary
- restore the board highlight blending values to their prior levels
- remove the helper that increased highlight opacity for block and crosshair highlights

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d84989fcb083268e16b8f33933bc91