### PR TITLE
Fix board edge grid lines

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -196,11 +196,35 @@ Border _cellBorder(
         width: bold ? scaledBoldLineWidth : scaledThinLineWidth,
       );
 
+  BorderSide? topSide;
+  if (isTopEdge) {
+    topSide = buildSide(bold: true);
+  } else if (showTop) {
+    topSide = buildSide(bold: false);
+  }
+
+  BorderSide? leftSide;
+  if (isLeftEdge) {
+    leftSide = buildSide(bold: true);
+  } else if (showLeft) {
+    leftSide = buildSide(bold: false);
+  }
+
+  BorderSide? rightSide;
+  if (isRightEdge || showRight) {
+    rightSide = buildSide(bold: true);
+  }
+
+  BorderSide? bottomSide;
+  if (isBottomEdge || showBottom) {
+    bottomSide = buildSide(bold: true);
+  }
+
   return Border(
-    top: showTop ? buildSide(bold: false) : BorderSide.none,
-    left: showLeft ? buildSide(bold: false) : BorderSide.none,
-    right: showRight ? buildSide(bold: true) : BorderSide.none,
-    bottom: showBottom ? buildSide(bold: true) : BorderSide.none,
+    top: topSide ?? BorderSide.none,
+    left: leftSide ?? BorderSide.none,
+    right: rightSide ?? BorderSide.none,
+    bottom: bottomSide ?? BorderSide.none,
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure Sudoku board cells draw bold borders along the outer edges
- keep existing logic for 3x3 block separators while making outer lines consistent

## Testing
- ⚠️ `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d85f3da6948326b0ea0e4e010fede5