### PR TITLE
Improve layered board highlights

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -283,15 +283,28 @@ class _BoardCell extends StatelessWidget {
             Color.alphaBlend(colors.blockHighlight, baseInner);
         final crosshairBackground =
             Color.alphaBlend(colors.crosshairHighlight, baseInner);
-        final backgroundColor = cell.isSelected
-            ? selectedBackground
-            : highlightSameValue
-                ? sameNumberBackground
-                : highlightBlock
-                    ? blockBackground
-                    : highlightCrosshair
-                        ? crosshairBackground
-                        : baseInner;
+        var backgroundColor = baseInner;
+        if (highlightCrosshair) {
+          backgroundColor = Color.alphaBlend(
+            colors.crosshairHighlight,
+            backgroundColor,
+          );
+        }
+        if (highlightBlock) {
+          backgroundColor = Color.alphaBlend(
+            colors.blockHighlight,
+            backgroundColor,
+          );
+        }
+        if (highlightSameValue) {
+          backgroundColor = Color.alphaBlend(
+            colors.sameNumberCell,
+            backgroundColor,
+          );
+        }
+        if (cell.isSelected) {
+          backgroundColor = selectedBackground;
+        }
 
         return GestureDetector(
           onTap: () => context.read<AppState>().selectCell(index),


### PR DESCRIPTION
## Summary
- layer crosshair, block, and same-number highlights instead of choosing only one
- ensure the selected cell color overrides combined highlights so the focus remains clear

## Testing
- flutter test *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8699c019c83268518e151f01a8cee