### PR TITLE
Use SF Pro Text font

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -640,7 +640,7 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
 
     return base.copyWith(
       textTheme: base.textTheme.apply(
-        fontFamily: 'SF Pro Display',
+        fontFamily: 'SF Pro Text',
         bodyColor: config.onSurface,
         displayColor: config.onSurface,
       ),


### PR DESCRIPTION
## Summary
- switch the application text theme to use the San Francisco Pro Text font so letters and digits render with the requested typography

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86da9feb08326bff924ef2679f113