### PR TITLE
Revert font change in Sudoku theme

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -640,7 +640,7 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
 
     return base.copyWith(
       textTheme: base.textTheme.apply(
-        fontFamily: 'SF Pro Text',
+        fontFamily: 'SF Pro Display',
         bodyColor: config.onSurface,
         displayColor: config.onSurface,
       ),


### PR DESCRIPTION
## Summary
- revert the merge that changed the text theme font to SF Pro Text
- restore the previous SF Pro Display font in the Sudoku theme configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86f8ace34832686d8861790183559