### PR TITLE
Separate classic and championship score tracking

### DIFF
--- a/lib/championship/championship_page.dart
+++ b/lib/championship/championship_page.dart
@@ -70,7 +70,10 @@ class ChampionshipPage extends StatelessWidget {
     final difficulty = championship.recommendedDifficulty;
     championship.startRound(difficulty);
     final app = context.read<AppState>();
-    app.startGame(difficulty);
+    app.startGame(
+      difficulty,
+      mode: GameMode.championship,
+    );
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const GamePage()),

--- a/lib/game_page.dart
+++ b/lib/game_page.dart
@@ -371,7 +371,7 @@ class _GamePageState extends State<GamePage>
       }
       int awardedDelta = 0;
       int? previousRank;
-      if (championship != null) {
+      if (championship != null && app.currentMode == GameMode.championship) {
         try {
           final difficulty = app.currentDifficulty ?? app.featuredDifficulty;
           final mistakes =

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -115,7 +115,7 @@ extension FontSizeOptionX on FontSizeOption {
 }
 
 /// Режим активной игры.
-enum GameMode { classic, daily, battle }
+enum GameMode { classic, daily, battle, championship }
 
 /// Состояние активной игры.
 class GameState {
@@ -934,7 +934,10 @@ class AppState extends ChangeNotifier {
   }
 
   /// Запуск новой игры выбранного уровня сложности.
-  void startGame(Difficulty diff) {
+  void startGame(
+    Difficulty diff, {
+    GameMode mode = GameMode.classic,
+  }) {
     final resolvedList =
         (puzzles[diff] ?? puzzles[Difficulty.novice]) ?? <Puzzle>[];
     if (resolvedList.isEmpty) {
@@ -974,7 +977,7 @@ class AppState extends ChangeNotifier {
 
     currentDifficulty = diff;
     featuredDifficulty = diff;
-    currentMode = GameMode.classic;
+    currentMode = mode;
     _sessionId++;
     currentScore = 0;
     selectedCell = null;


### PR DESCRIPTION
## Summary
- add a dedicated championship game mode when starting games from the championship flow
- prevent championship score awards when finishing classic games

## Testing
- Tests not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d90f34f75c832689e54aaebf5bf3e2