### PR TITLE
Increase incorrect input shake amplitude

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -222,7 +222,7 @@ class _IncorrectShakeAnimation extends StatelessWidget {
       builder: (context, value, child) {
         final eased = Curves.easeOut.transform(value);
         final damping = math.max(0, 1 - eased);
-        final amplitude = 3.0 * scale;
+        final amplitude = 6.0 * scale;
         final offset = math.sin(eased * math.pi * _oscillations) * amplitude * damping;
         return Transform.translate(
           offset: Offset(offset, 0),


### PR DESCRIPTION
## Summary
- increase the incorrect-input shake animation amplitude to make the feedback more noticeable while keeping timing the same

## Testing
- `flutter test` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9442571a883268ed62f87489fab67