### PR TITLE
Revert Android version bump

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,8 +26,8 @@ android {
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 21
         targetSdk = 36
-        versionCode = 3
-        versionName = "1.0.2"
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- revert the Android build configuration to use Flutter-managed versionCode and versionName values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97552df60832684d9aa7048d7b8cb