### PR TITLE
Configure SF Pro font for the app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,10 @@ class SudokuApp extends StatelessWidget {
     final activeTheme = app.resolvedTheme();
     final theme = buildSudokuTheme(
       activeTheme,
-    ).copyWith(pageTransitionsTheme: _pageTransitionsTheme);
+    ).copyWith(
+      pageTransitionsTheme: _pageTransitionsTheme,
+      fontFamily: 'SF Pro',
+    );
 
     return MaterialApp(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,14 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  fonts:
+    - family: SF Pro
+      fonts:
+        - asset: assets/fonts/SF-Pro-Display-Regular.otf
+        - asset: assets/fonts/SF-Pro-Display-Medium.otf
+          weight: 500
+        - asset: assets/fonts/SF-Pro-Display-Bold.otf
+          weight: 700
   generate: true
 
   assets:


### PR DESCRIPTION
## Summary
- register the SF Pro font assets in the Flutter configuration
- apply the SF Pro font family to the global app theme

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dae4f35be88326b0c831d0fb1a847c