### PR TITLE
Fix SF Pro font configuration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,11 +53,9 @@ class SudokuApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final app = context.watch<models.AppState>();
     final activeTheme = app.resolvedTheme();
-    final theme = buildSudokuTheme(
-      activeTheme,
-    ).copyWith(
+    final baseTheme = buildSudokuTheme(activeTheme);
+    final theme = baseTheme.copyWith(
       pageTransitionsTheme: _pageTransitionsTheme,
-      fontFamily: 'SF Pro',
     );
 
     return MaterialApp(

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -645,11 +645,11 @@ ThemeData buildSudokuTheme(SudokuTheme theme) {
       brightness: config.brightness,
       scaffoldBackgroundColor: config.background,
       shadowColor: config.colors.shadowColor,
+      fontFamily: 'SF Pro',
     );
 
     return base.copyWith(
       textTheme: base.textTheme.apply(
-        fontFamily: 'SF Pro Display',
         bodyColor: config.onSurface,
         displayColor: config.onSurface,
       ),


### PR DESCRIPTION
## Summary
- remove the invalid `fontFamily` override from the Sudoku app theme setup
- configure the shared Sudoku theme to use the bundled SF Pro font family

## Testing
- not run (Flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dae9d439e08326ab67105edaf1ff11