### PR TITLE
Remove perfect combo rewards and center toast overlay

### DIFF
--- a/lib/combo/combo_controller.dart
+++ b/lib/combo/combo_controller.dart
@@ -16,14 +16,13 @@ abstract class ComboHost {
   double get fontScale;
 }
 
-enum _ToastType { combo, streak, perfectRow, perfectColumn, perfectBox, speed }
+enum _ToastType { combo, streak, speed }
 
 class ComboController implements ComboEventSink {
   ComboController({required this.host});
 
   static const _comboIcon = 'assets/icons/combos/combo.svg';
   static const _streakIcon = 'assets/icons/combos/streak.svg';
-  static const _perfectIcon = 'assets/icons/combos/perfect.svg';
   static const _speedIcon = 'assets/icons/combos/speed.svg';
 
   final ComboHost host;
@@ -110,21 +109,6 @@ class ComboController implements ComboEventSink {
         _maybeHaptic();
       }
     }
-  }
-
-  @override
-  void onPerfectRow(Difficulty? difficulty) {
-    _emitPerfectToast(_ToastType.perfectRow, difficulty);
-  }
-
-  @override
-  void onPerfectColumn(Difficulty? difficulty) {
-    _emitPerfectToast(_ToastType.perfectColumn, difficulty);
-  }
-
-  @override
-  void onPerfectBox(Difficulty? difficulty) {
-    _emitPerfectToast(_ToastType.perfectBox, difficulty);
   }
 
   @override
@@ -215,38 +199,6 @@ class ComboController implements ComboEventSink {
     _pendingMoveToasts.clear();
     _pendingMoveTimer?.cancel();
     _pendingMoveTimer = null;
-  }
-
-  void _emitPerfectToast(_ToastType type, Difficulty? difficulty) {
-    final l10n = AppLocalizations.of(host.context);
-    if (l10n == null) {
-      return;
-    }
-    String label;
-    switch (type) {
-      case _ToastType.perfectRow:
-        label = l10n.perfectRow;
-        break;
-      case _ToastType.perfectColumn:
-        label = l10n.perfectCol;
-        break;
-      case _ToastType.perfectBox:
-        label = l10n.perfectBox;
-        break;
-      default:
-        label = '';
-    }
-    if (label.isEmpty) {
-      return;
-    }
-    _collectMoveToast(
-      _ToastRequest(
-        type: type,
-        label: label,
-        iconAsset: _perfectIcon,
-        difficulty: difficulty,
-      ),
-    );
   }
 
   void _startMoveAggregation(int timestampMs) {
@@ -451,15 +403,11 @@ class ComboController implements ComboEventSink {
                   begin: Offset(0, comboTheme.offsetY / -56.0),
                   end: Offset.zero,
                 ).animate(animation);
-          final safeTop = media.padding.top;
           final maxWidth = math.min(media.size.width * 0.9, 360.0);
-          return Positioned(
-            top: safeTop + comboTheme.offsetY,
-            left: 0,
-            right: 0,
+          return Positioned.fill(
             child: IgnorePointer(
               child: Align(
-                alignment: Alignment.topCenter,
+                alignment: Alignment.center,
                 child: FadeTransition(
                   opacity: fade,
                   child: SlideTransition(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Perfekte Zeile",
-  "perfect_col": "Perfekte Spalte",
-  "perfect_box": "Perfekter Block",
   "speed_bonus": "Tempo-Bonus {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Perfekte Zeile",
-  "perfectCol": "Perfekte Spalte",
-  "perfectBox": "Perfekter Block",
   "noActiveGameMessage": "Kein aktives Spiel. Kehre zum Startbildschirm zurück.",
   "victoryTitle": "Glückwunsch!",
   "victoryMessage": "Rätsel gelöst in {time}.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -198,9 +198,6 @@
       }
     }
   },
-  "perfect_row": "Perfect Row",
-  "perfect_col": "Perfect Column",
-  "perfect_box": "Perfect Box",
   "speed_bonus": "Speed Bonus {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -236,9 +233,6 @@
       }
     }
   },
-  "perfectRow": "Perfect Row",
-  "perfectCol": "Perfect Column",
-  "perfectBox": "Perfect Box",
   "noActiveGameMessage": "No active game. Return to the home screen.",
   "victoryTitle": "Congratulations!",
   "victoryMessage": "Puzzle solved in {time}.",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Fila perfecta",
-  "perfect_col": "Columna perfecta",
-  "perfect_box": "Cuadro perfecto",
   "speed_bonus": "Bonificación de velocidad {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Fila perfecta",
-  "perfectCol": "Columna perfecta",
-  "perfectBox": "Cuadro perfecto",
   "noActiveGameMessage": "No hay juego activo. Regrese a la pantalla de inicio.",
   "victoryTitle": "¡Felicidades!",
   "victoryMessage": "Rompecabezas resuelto en {time}.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Ligne parfaite",
-  "perfect_col": "Colonne parfaite",
-  "perfect_box": "Bloc parfait",
   "speed_bonus": "Bonus de vitesse {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Ligne parfaite",
-  "perfectCol": "Colonne parfaite",
-  "perfectBox": "Bloc parfait",
   "noActiveGameMessage": "Aucune partie en cours. Revenez à l'écran d'accueil.",
   "victoryTitle": "Félicitations !",
   "victoryMessage": "Énigme résolue en {time}.",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "परफ़ेक्ट पंक्ति",
-  "perfect_col": "परफ़ेक्ट स्तंभ",
-  "perfect_box": "परफ़ेक्ट बॉक्स",
   "speed_bonus": "स्पीड बोनस {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "परफ़ेक्ट पंक्ति",
-  "perfectCol": "परफ़ेक्ट स्तंभ",
-  "perfectBox": "परफ़ेक्ट बॉक्स",
   "noActiveGameMessage": "कोई सक्रिय खेल नहीं। होम स्क्रीन पर लौटें।",
   "victoryTitle": "बधाई!",
   "victoryMessage": "{time} में पहेली हल हुई।",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Riga perfetta",
-  "perfect_col": "Colonna perfetta",
-  "perfect_box": "Box perfetto",
   "speed_bonus": "Bonus velocità {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Riga perfetta",
-  "perfectCol": "Colonna perfetta",
-  "perfectBox": "Box perfetto",
   "noActiveGameMessage": "Nessun gioco attivo. Torna alla schermata principale.",
   "victoryTitle": "Congratulazioni!",
   "victoryMessage": "Schema risolto in {time}.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "パーフェクト行",
-  "perfect_col": "パーフェクト列",
-  "perfect_box": "パーフェクトブロック",
   "speed_bonus": "スピードボーナス {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "パーフェクト行",
-  "perfectCol": "パーフェクト列",
-  "perfectBox": "パーフェクトブロック",
   "noActiveGameMessage": "アクティブなゲームはありません。ホーム画面に戻ります。",
   "victoryTitle": "おめでとう！",
   "victoryMessage": "パズルを {time} で解きました。",

--- a/lib/l10n/app_ka.arb
+++ b/lib/l10n/app_ka.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "სრულყოფილი რიგი",
-  "perfect_col": "სრულყოფილი სვეტი",
-  "perfect_box": "სრულყოფილი ბლოკი",
   "speed_bonus": "სისწრაფის ბონუსი {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "სრულყოფილი რიგი",
-  "perfectCol": "სრულყოფილი სვეტი",
-  "perfectBox": "სრულყოფილი ბლოკი",
   "noActiveGameMessage": "აქტიური თამაში არ არის. დაბრუნდით მთავარ ეკრანზე.",
   "victoryTitle": "გილოცავთ!",
   "victoryMessage": "თავსატეხი ამოხსნილია {time}-ში.",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "완벽한 행",
-  "perfect_col": "완벽한 열",
-  "perfect_box": "완벽한 박스",
   "speed_bonus": "속도 보너스 {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "완벽한 행",
-  "perfectCol": "완벽한 열",
-  "perfectBox": "완벽한 박스",
   "noActiveGameMessage": "능동적 인 게임이 없습니다. 홈 화면으로 돌아갑니다.",
   "victoryTitle": "축하해요!",
   "victoryMessage": "퍼즐을 {time}에 해결했습니다.",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Идеальная строка",
-  "perfect_col": "Идеальный столбец",
-  "perfect_box": "Идеальный блок",
   "speed_bonus": "Бонус скорости {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Идеальная строка",
-  "perfectCol": "Идеальный столбец",
-  "perfectBox": "Идеальный блок",
   "noActiveGameMessage": "Нет активной игры. Вернитесь на главный экран.",
   "victoryTitle": "Поздравляем!",
   "victoryMessage": "Головоломка решена за {time}.",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "Ідеальний рядок",
-  "perfect_col": "Ідеальний стовпець",
-  "perfect_box": "Ідеальний блок",
   "speed_bonus": "Бонус швидкості {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "Ідеальний рядок",
-  "perfectCol": "Ідеальний стовпець",
-  "perfectBox": "Ідеальний блок",
   "noActiveGameMessage": "Немає активної гри. Поверніться на головний екран.",
   "victoryTitle": "Вітаємо!",
   "victoryMessage": "Головоломку розв'язано за {time}.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -197,9 +197,6 @@
       }
     }
   },
-  "perfect_row": "完美行",
-  "perfect_col": "完美列",
-  "perfect_box": "完美宫",
   "speed_bonus": "极速奖励 {time}",
   "@speed_bonus": {
     "placeholders": {
@@ -235,9 +232,6 @@
       }
     }
   },
-  "perfectRow": "完美行",
-  "perfectCol": "完美列",
-  "perfectBox": "完美宫",
   "noActiveGameMessage": "没有进行中的游戏。返回主界面。",
   "victoryTitle": "恭喜！",
   "victoryMessage": "在 {time} 内完成谜题。",


### PR DESCRIPTION
## Summary
- remove perfect row/column/box combo badge triggers and their supporting state
- center the combo toast overlay while preserving existing animation behavior
- drop unused localization strings associated with the perfect combo badges

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db01af403883268ad132662a94e380