### PR TITLE
Update confirm text translations

### DIFF
--- a/lib/flutter_gen/gen_l10n/app_localizations.dart
+++ b/lib/flutter_gen/gen_l10n/app_localizations.dart
@@ -5368,7 +5368,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get confirmFlagSelectionMessage => "Вы уверены, что хотите выбрать этот флаг? Флаг можно будет изменить в настройках игры.";
 
   @override
-  String get confirmFlagSelectionConfirm => "Подтверждаю";
+  String get confirmFlagSelectionConfirm => "Принять";
 
   @override
   String get startAction => "Начать";
@@ -5905,7 +5905,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get confirmFlagSelectionMessage => "Ти впевнений, що хочеш обрати цей прапор? Ти зможеш змінити прапор пізніше в налаштуваннях гри.";
 
   @override
-  String get confirmFlagSelectionConfirm => "Підтверджую";
+  String get confirmFlagSelectionConfirm => "Приймаю";
 
   @override
   String get startAction => "Почати";

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -92,7 +92,7 @@
   "selectPlayerFlag": "Выбери свой флаг",
   "confirmFlagSelectionTitle": "Подтвердите флаг",
   "confirmFlagSelectionMessage": "Вы уверены, что хотите выбрать этот флаг? Флаг можно будет изменить в настройках игры.",
-  "confirmFlagSelectionConfirm": "Подтверждаю",
+  "confirmFlagSelectionConfirm": "Принять",
   "startAction": "Начать",
   "levelHeading": "Уровень {level} — {difficulty}",
   "@levelHeading": {

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -92,7 +92,7 @@
   "selectPlayerFlag": "Обери свій прапор",
   "confirmFlagSelectionTitle": "Підтвердь свій прапор",
   "confirmFlagSelectionMessage": "Ти впевнений, що хочеш обрати цей прапор? Ти зможеш змінити прапор пізніше в налаштуваннях гри.",
-  "confirmFlagSelectionConfirm": "Підтверджую",
+  "confirmFlagSelectionConfirm": "Приймаю",
   "startAction": "Почати",
   "levelHeading": "Рівень {level} — {difficulty}",
   "@levelHeading": {


### PR DESCRIPTION
## Summary
- replace the Ukrainian confirmation string with "Приймаю"
- replace the Russian confirmation string with "Принять"
- update generated localization getters to match the new strings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db0cf441f88326ac7be92e309bdc16