### PR TITLE
Bump build number to 4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+3
+version: 1.0.1+4
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
## Summary
- increment the Flutter build number to 4 to avoid Android version code conflicts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db183d7bd083269f02f558cc623720