### PR TITLE
Ensure hints always fill a random unsolved cell

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1437,21 +1437,17 @@ class AppState extends ChangeNotifier {
     if (game == null) return;
     if (hintsLeft <= 0) return;
 
-    int? idx = selectedCell;
-    if (idx == null) {
-      final available = <int>[];
-      for (var i = 0; i < game.board.length; i++) {
-        if (!_isFixedCell(game, i) && game.board[i] == 0) {
-          available.add(i);
-        }
+    final available = <int>[];
+    for (var i = 0; i < game.board.length; i++) {
+      if (!_isFixedCell(game, i) && game.board[i] != game.solution[i]) {
+        available.add(i);
       }
-      if (available.isEmpty) {
-        return;
-      }
-      idx = available[_random.nextInt(available.length)];
+    }
+    if (available.isEmpty) {
+      return;
     }
 
-    if (_isFixedCell(game, idx)) return;
+    final idx = available[_random.nextInt(available.length)];
 
     final previousValue = game.board[idx];
     final previousNotes = _cloneNotes(idx);


### PR DESCRIPTION
## Summary
- adjust hint usage logic to ignore the currently selected cell
- always choose a random unfixed cell that is not yet solved for hint placement

## Testing
- not run (environment not configured for Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68dc20c2438c8326b8e98cd212bdd1de