### PR TITLE
Fix sigma type for highlight blur mask filter

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -345,7 +345,7 @@ class _HintHighlightPainter extends CustomPainter {
     if (borderWidth > 0) {
       final sigma = blurRadius > 0
           ? (blurRadius * 0.57735 + 0.5)
-          : 0;
+          : 0.0;
       final borderPaint = Paint()
         ..color = color.withOpacity(0.55 * intensity)
         ..style = PaintingStyle.stroke


### PR DESCRIPTION
## Summary
- ensure the blur sigma used for the highlight border is always a double value

## Testing
- flutter test *(fails: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2e42f7948326ac31d9807b1ca2ae