### PR TITLE
Fix hint highlight overlay visibility

### DIFF
--- a/lib/widgets/board.dart
+++ b/lib/widgets/board.dart
@@ -533,7 +533,12 @@ class _BoardCell extends StatelessWidget {
                         ? crosshairBackground
                         : baseInner;
 
-        Widget content = Stack(
+        Widget content = Container(
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            border: border,
+          ),
+          child: Stack(
             fit: StackFit.expand,
             children: [
               if (cell.hintHighlightId != 0)
@@ -544,21 +549,16 @@ class _BoardCell extends StatelessWidget {
                     scale: scale,
                   ),
                 ),
-              Container(
-                decoration: BoxDecoration(
-                  color: backgroundColor,
-                  border: border,
-                ),
-                child: _CellContent(
-                  value: cell.value,
-                  notes: cell.notes,
-                  incorrect: cell.incorrect,
-                  fontScale: cell.fontScale,
-                  valueAnimationId: cell.valueAnimationId,
-                ),
+              _CellContent(
+                value: cell.value,
+                notes: cell.notes,
+                incorrect: cell.incorrect,
+                fontScale: cell.fontScale,
+                valueAnimationId: cell.valueAnimationId,
               ),
             ],
-          );
+          ),
+        );
 
         if (cell.incorrectAnimationId != 0) {
           content = _IncorrectShakeAnimation(


### PR DESCRIPTION
## Summary
- move the hint highlight overlay inside the cell container so it renders above the background
- keep the cell value content above the highlight so numbers remain visible while the glow animates

## Testing
- flutter test *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc334f4050832688343c394f23603d