### PR TITLE
Revert "Adjust rank banner styling in difficulty sheet"

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1529,8 +1529,9 @@ class _DifficultyTile extends StatelessWidget {
           color: rankColor,
         );
 
+    final progressColor = palette.progressTextColor;
     final progressStyle = theme.textTheme.bodySmall?.copyWith(
-          color: rankColor,
+          color: progressColor,
           fontWeight: FontWeight.w600,
           fontSize:
               (theme.textTheme.bodySmall?.fontSize ?? 12) * scale,
@@ -1538,7 +1539,7 @@ class _DifficultyTile extends StatelessWidget {
         TextStyle(
           fontSize: 12 * scale,
           fontWeight: FontWeight.w600,
-          color: rankColor,
+          color: progressColor,
         );
 
     final trackColor = isActive
@@ -1579,41 +1580,37 @@ class _DifficultyTile extends StatelessWidget {
                     ),
                   ),
                   SizedBox(width: 14 * scale),
-                  ConstrainedBox(
-                    constraints: BoxConstraints(minWidth: 112 * scale),
-                    child: Container(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 12 * scale,
-                        vertical: 8 * scale,
-                      ),
-                      decoration: BoxDecoration(
-                        color: rankBackground,
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(16 * scale),
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Container(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 12 * scale,
+                          vertical: 5 * scale,
+                        ),
+                        decoration: BoxDecoration(
+                          color: rankBackground,
+                          borderRadius: BorderRadius.all(
+                            Radius.circular(999 * scale),
+                          ),
+                        ),
+                        child: Text(
+                          rankLabel,
+                          style: rankStyle,
                         ),
                       ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Text(
-                            rankLabel,
-                            style: rankStyle,
-                            textAlign: TextAlign.center,
-                          ),
-                          if (progressText != null) ...[
-                            SizedBox(height: 4 * scale),
-                            Text(
-                              progressText,
-                              style: progressStyle,
-                              textAlign: TextAlign.center,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
+                      if (progressText != null) ...[
+                        SizedBox(height: 4 * scale),
+                        Text(
+                          progressText,
+                          style: progressStyle,
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ],
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- revert the merge of PR #238 so the difficulty tile layout and styling return to their previous state

## Testing
- flutter test *(fails: Flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcfa20a2c483269f75b7bc7e53d943