### PR TITLE
Adjust difficulty tile height and progress indicator behavior

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1344,6 +1344,7 @@ class _ProgressCard extends StatelessWidget {
 }
 
 const double _difficultyTileRadiusValue = 20.0;
+const double _difficultyTileHeightScale = 0.95;
 const Duration _difficultyProgressAnimationDuration =
     Duration(milliseconds: 320);
 
@@ -1554,7 +1555,7 @@ class _DifficultyTile extends StatelessWidget {
           borderRadius: borderRadius,
           child: Stack(
             children: [
-              if (progressText != null && clampedProgress > 0)
+              if (progressText != null && clampedProgress > 0 && isActive)
                 Positioned.fill(
                   child: LayoutBuilder(
                     builder: (context, constraints) {
@@ -1578,7 +1579,7 @@ class _DifficultyTile extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.symmetric(
                   horizontal: 17 * scale,
-                  vertical: 12.75 * scale,
+                  vertical: 12.75 * _difficultyTileHeightScale * scale,
                 ),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
@@ -1603,7 +1604,8 @@ class _DifficultyTile extends StatelessWidget {
                             Container(
                               padding: EdgeInsets.symmetric(
                                 horizontal: 12 * scale,
-                                vertical: 5 * scale,
+                                vertical:
+                                    5 * _difficultyTileHeightScale * scale,
                               ),
                               decoration: BoxDecoration(
                                 color: rankBackground,
@@ -1617,7 +1619,9 @@ class _DifficultyTile extends StatelessWidget {
                               ),
                             ),
                             if (progressText != null) ...[
-                              SizedBox(height: 4 * scale),
+                              SizedBox(
+                                  height:
+                                      4 * _difficultyTileHeightScale * scale),
                               Text(
                                 progressText,
                                 style: progressStyle,


### PR DESCRIPTION
## Summary
- reduce vertical padding within difficulty tiles to shrink their height by roughly five percent
- restrict the animated progress fill to the active difficulty selection so inactive tiles stay flat

## Testing
- flutter test *(fails: `flutter` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcff39f4e883268fa5cb20bbd6b363