### PR TITLE
chore: bump version to 1.0.2+7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+6
+version: 1.0.2+7
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
## Summary
- bump the Flutter app version to 1.0.2+7

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0260c8ec8326919f80a9b324f0e4