### PR TITLE
Reduce difficulty banner height by 10%

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1386,7 +1386,7 @@ class _ProgressCard extends StatelessWidget {
 }
 
 const double _difficultyTileRadiusValue = 20.0;
-const double _difficultyTileHeightScale = 0.95;
+const double _difficultyTileHeightScale = 0.855;
 const Duration _difficultyProgressAnimationDuration =
     Duration(milliseconds: 320);
 


### PR DESCRIPTION
## Summary
- decrease the difficulty banner height scale to shrink banner height by 10%

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd29787d388326b3a82a49ed441099