### PR TITLE
Adjust rank badge color

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1395,6 +1395,8 @@ class _ProgressCard extends StatelessWidget {
 const double _difficultyTileRadiusValue = 20.0;
 const double _difficultyTileHeightScale = 0.855;
 const Duration _difficultyTapAnimationDuration = Duration(milliseconds: 820);
+const Color _rankBadgeBackgroundColor = Color(0xFF3B73ED);
+const Color _rankBadgeTextColor = Color(0xFFFFFFFF);
 
 class _DifficultySheetPalette {
   final Color tileBackground;
@@ -1437,10 +1439,10 @@ class _DifficultySheetPalette {
       return _DifficultySheetPalette(
         tileBackground: overlay(cs.onSurface, 0.12),
         tileActiveBackground: overlay(cs.primary, 0.32),
-        badgeBackground: overlay(cs.onSurface, 0.18),
-        badgeActiveBackground: cs.primary,
-        badgeTextColor: cs.onSurface.withOpacity(0.75),
-        badgeActiveTextColor: cs.onPrimary,
+        badgeBackground: _rankBadgeBackgroundColor,
+        badgeActiveBackground: _rankBadgeBackgroundColor,
+        badgeTextColor: _rankBadgeTextColor,
+        badgeActiveTextColor: _rankBadgeTextColor,
         progressTextColor: cs.onSurfaceVariant,
         titleColor: cs.onSurface,
         closeBackground: overlay(cs.onSurface, 0.16),
@@ -1453,10 +1455,10 @@ class _DifficultySheetPalette {
     return _DifficultySheetPalette(
       tileBackground: overlay(cs.onSurface, 0.04),
       tileActiveBackground: overlay(cs.primary, 0.18),
-      badgeBackground: overlay(cs.onSurface, 0.06),
-      badgeActiveBackground: cs.primary,
-      badgeTextColor: cs.onSurface.withOpacity(0.65),
-      badgeActiveTextColor: cs.onPrimary,
+      badgeBackground: _rankBadgeBackgroundColor,
+      badgeActiveBackground: _rankBadgeBackgroundColor,
+      badgeTextColor: _rankBadgeTextColor,
+      badgeActiveTextColor: _rankBadgeTextColor,
       progressTextColor: cs.onSurface.withOpacity(0.6),
       titleColor: cs.onSurface,
       closeBackground: overlay(cs.onSurface, 0.05),


### PR DESCRIPTION
## Summary
- introduce shared constants for the difficulty sheet rank badge colors
- keep the badge background consistently blue with a softened shade across difficulty states
- ensure the badge text color stays white regardless of selection

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8fba54b88326b7dc9182d8c8ec53