### PR TITLE
Adjust difficulty animation start position

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1773,7 +1773,7 @@ class _DifficultyTileState extends State<_DifficultyTile>
   }
 
   void _configureAnimation() {
-    final begin = _clampedProgress;
+    final begin = widget.isActive ? _clampedProgress : 0.0;
     _progressAnimation = TweenSequence<double>([
       TweenSequenceItem(
         tween: Tween<double>(begin: begin, end: 0.0)


### PR DESCRIPTION
## Summary
- update the difficulty tile animation so it begins at the left edge for non-active selections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd99e5ce648326929bb5707bde37a8