### PR TITLE
Fix daily challenge tile animation

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1582,7 +1582,7 @@ class _DailyChallengeTile extends StatefulWidget {
 class _DailyChallengeTileState extends State<_DailyChallengeTile>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
-  late final Animation<double> _progressAnimation;
+  late Animation<double> _progressAnimation;
   bool _isAnimating = false;
   bool _didSubmit = false;
   bool _suppressSubmit = false;


### PR DESCRIPTION
## Summary
- allow the daily challenge tile animation to be rebuilt so tapping it no longer throws

## Testing
- Unable to run tests: flutter is not installed in the environment

------
https://chatgpt.com/codex/tasks/task_e_68dda55338548326af97455c34990572