### PR TITLE
Keep daily challenge selected in difficulty sheet

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -315,6 +315,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
         final palette = _DifficultySheetPalette.fromTheme(theme);
         final scale = context.layoutScale;
         final selected = app.featuredStatsDifficulty;
+        final isDailySelected = app.isFeaturedDailyChallenge;
         final sheetL10n = AppLocalizations.of(context)!;
 
         final today = DateTime.now();
@@ -333,7 +334,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
             title: sheetL10n.selectDifficultyDailyChallenge,
             subtitle: todayLabel,
             isCompleted: isDailyCompleted,
-            isActive: isDailyActive,
+            isActive: isDailyActive || isDailySelected,
             palette: palette,
             onSubmit: () {
               if (context.mounted) {
@@ -347,7 +348,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
             lockTap: () => isTapLocked = true,
             scale: scale,
             onTapped: (state) async {
-              if (isDailyActive) {
+              if (isDailyActive || isDailySelected) {
                 await state.playSelectionAnimation();
                 return;
               }
@@ -370,7 +371,7 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
               rankLabel: sheetL10n.rankLabel(stats.rank),
               progressCurrent: stats.progressCurrent,
               progressTarget: stats.progressTarget,
-              isActive: diff == selected,
+              isActive: !isDailySelected && diff == selected,
               palette: palette,
               onSubmit: () {
                 if (context.mounted) {
@@ -384,11 +385,11 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
               lockTap: () => isTapLocked = true,
               scale: scale,
               onTapped: (state) async {
-                if (diff == selected) {
+                if (!isDailySelected && diff == selected) {
                   await state.playSelectionAnimation();
                   return;
                 }
-                if (isDailyActive) {
+                if (isDailyActive || isDailySelected) {
                   final dailyState = dailyTileKey.currentState;
                   if (dailyState != null) {
                     await dailyState.playResetAnimation();

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -285,6 +285,7 @@ class AppState extends ChangeNotifier {
   Difficulty? currentDifficulty;
   GameMode? currentMode;
   Difficulty featuredDifficulty = Difficulty.novice;
+  bool _isFeaturedDailyChallenge = false;
 
   String? playerFlag;
   bool tutorialSeen = false;
@@ -350,6 +351,7 @@ class AppState extends ChangeNotifier {
       _dailyChallengeDate = null;
       _currentGameId = null;
       _lastVictoryDate = null;
+      _isFeaturedDailyChallenge = false;
 
       final completedDaily = prefs.getStringList('dailyCompleted');
       if (completedDaily != null) {
@@ -592,6 +594,8 @@ class AppState extends ChangeNotifier {
                 : DateTime.tryParse(dailyDateString);
             _dailyChallengeDate =
                 parsedDailyDate == null ? null : _dateOnly(parsedDailyDate);
+            _isFeaturedDailyChallenge = currentMode == GameMode.daily ||
+                _dailyChallengeDate != null;
 
             _currentGameId = (map['gameId'] as String?)?.trim();
             if (diff != null && (_currentGameId == null || _currentGameId!.isEmpty)) {
@@ -919,6 +923,7 @@ class AppState extends ChangeNotifier {
     currentDifficulty = Difficulty.medium;
     featuredDifficulty = Difficulty.medium;
     currentMode = GameMode.daily;
+    _isFeaturedDailyChallenge = true;
     _dailyChallengeDate = normalized;
     _sessionId++;
     currentScore = 0;
@@ -946,6 +951,7 @@ class AppState extends ChangeNotifier {
     Difficulty diff, {
     GameMode mode = GameMode.classic,
   }) {
+    _isFeaturedDailyChallenge = false;
     final resolvedList =
         (puzzles[diff] ?? puzzles[Difficulty.novice]) ?? <Puzzle>[];
     if (resolvedList.isEmpty) {
@@ -1185,6 +1191,8 @@ class AppState extends ChangeNotifier {
     }
     return featuredDifficulty;
   }
+
+  bool get isFeaturedDailyChallenge => _isFeaturedDailyChallenge;
 
   void selectCell(int index) {
     if (current == null) return;


### PR DESCRIPTION
## Summary
- track whether the daily challenge was the last selected option and expose it through app state
- update the difficulty sheet so the daily challenge tile highlights and animates like other difficulty tiles

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddaa0599788326876e433cab66c219