### PR TITLE
Remove swipe animation when starting game

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -471,7 +471,12 @@ class _HomeTabState extends State<_HomeTab> with AutomaticKeepAliveClientMixin {
     app.startGame(difficulty);
     Navigator.push(
       context,
-      MaterialPageRoute(builder: (_) => const GamePage()),
+      PageRouteBuilder(
+        pageBuilder: (_, __, ___) => const GamePage(),
+        transitionDuration: Duration.zero,
+        reverseTransitionDuration: Duration.zero,
+        transitionsBuilder: (_, __, ___, child) => child,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- replace the MaterialPageRoute used after selecting a difficulty with a PageRouteBuilder that has zero-duration transitions
- keep the existing difficulty picker animation while making the transition into the game instantaneous

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df00c4a8fc8326a412f5a7ddf578d2