### PR TITLE
Add test notification button to settings

### DIFF
--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -150,6 +150,26 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           ListTile(
+            key: const ValueKey('settings-test-alert'),
+            leading: Icon(Icons.notification_add_outlined, size: iconSize),
+            title: const Text('Test notification'),
+            onTap: () {
+              showDialog<void>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Test notification'),
+                  content: const Text('Это тестовое оповещение.'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text(l10n.ok),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+          ListTile(
             key: const ValueKey('settings-about'),
             leading: Icon(Icons.info_outline, size: iconSize),
             title: Text(l10n.aboutApp),


### PR DESCRIPTION
## Summary
- add a temporary test notification button to the settings screen
- show an informational alert dialog when the button is pressed

## Testing
- flutter test *(fails: Flutter SDK not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df10fe63748326a3dcf606f1bef61a