### PR TITLE
Fix test alert dialog localization

### DIFF
--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -162,7 +162,7 @@ class SettingsPage extends StatelessWidget {
                   actions: [
                     TextButton(
                       onPressed: () => Navigator.of(context).pop(),
-                      child: Text(l10n.ok),
+                      child: Text(l10n.done),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Summary
- replace the nonexistent `l10n.ok` accessor with the existing `l10n.done` string in the settings test alert dialog

## Testing
- flutter test *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df1250f1148326bce33cddf489a5df