### PR TITLE
Enable core library desugaring for Android build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- enable core library desugaring to satisfy flutter_local_notifications metadata requirements
- add desugaring dependency to the Android app module

## Testing
- not run (tool unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df13942a508326946034402f8a6715