### PR TITLE
Replace flutter_timezone dependency with native timezone channel

### DIFF
--- a/android/app/src/main/kotlin/com/sudoku/uzor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/sudoku/uzor/MainActivity.kt
@@ -1,5 +1,22 @@
 package com.sudoku.uzor
 
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.util.TimeZone
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channelName = "com.sudoku.uzor/timezone"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getLocalTimezone" -> result.success(TimeZone.getDefault().id)
+                    else -> result.notImplemented()
+                }
+            }
+    }
+}

--- a/lib/notifications/notification_scheduler.dart
+++ b/lib/notifications/notification_scheduler.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
+import 'timezone_provider.dart';
 
 /// Handles scheduling of local notifications that remind players to solve
 /// Sudoku puzzles.
@@ -62,7 +62,7 @@ class NotificationScheduler {
   Future<void> _configureLocalTimeZone() async {
     tzdata.initializeTimeZones();
     try {
-      final timeZoneName = await FlutterTimezone.getLocalTimezone();
+      final timeZoneName = await TimezoneProvider.getLocalTimezone();
       final location = tz.getLocation(timeZoneName);
       tz.setLocalLocation(location);
     } catch (_) {

--- a/lib/notifications/timezone_provider.dart
+++ b/lib/notifications/timezone_provider.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+/// Provides access to the device timezone on Android devices via a method
+/// channel. Falls back to UTC when the value cannot be retrieved.
+class TimezoneProvider {
+  TimezoneProvider._();
+
+  static const _channel = MethodChannel('com.sudoku.uzor/timezone');
+
+  /// Retrieves the local timezone name.
+  static Future<String> getLocalTimezone() async {
+    if (!Platform.isAndroid) {
+      return 'UTC';
+    }
+
+    try {
+      final result = await _channel.invokeMethod<String>('getLocalTimezone');
+      return result ?? 'UTC';
+    } on PlatformException {
+      return 'UTC';
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   video_player: ^2.9.2
   url_launcher: ^6.3.2
   flutter_local_notifications: ^17.2.1
-  flutter_timezone: ^1.0.8
   timezone: ^0.9.4
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- remove the flutter_timezone plugin dependency and add a simple timezone provider
- expose the device timezone from Android through a MethodChannel
- update the notification scheduler to use the new provider with a UTC fallback

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df18f25eb48326864641dc4523db8b