### PR TITLE
Add exact alarm permission for Android reminders

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:label="Sudoku - Sudoku Classic Game"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- declare the SCHEDULE_EXACT_ALARM permission in the Android manifest so reminders can be enabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfca837de883268e332eb08b646496